### PR TITLE
Update tooltip to invert default description for namedargs

### DIFF
--- a/docs/Help/Topics/PropPage-Language.xml
+++ b/docs/Help/Topics/PropPage-Language.xml
@@ -80,7 +80,7 @@
           <para styleclass="Normal">Allow Named Arguments</para>
         </td>
         <td>
-          <para styleclass="Normal">Allow named arguments (Default = FALSE for the Core dialect and TRUE for the other dialects). Changing the dialect may also automatically change this setting.</para>
+          <para styleclass="Normal">Allow named arguments (Default = TRUE for the Core dialect and FALSE for the other dialects). Changing the dialect may also automatically change this setting.</para>
         </td>
         <td>
           <para styleclass="Normal"><link displaytype="text" defaultstyle="true" type="topiclink" href="opt-namedargs">/namedargs</link></para>

--- a/src/VisualStudio/XSharpCodeModelXs/Settings/Strings.prg
+++ b/src/VisualStudio/XSharpCodeModelXs/Settings/Strings.prg
@@ -129,7 +129,7 @@ class LanguagePropertyPagePanel
     const AZDescription := "Use Zero Based Arrays (/az)" as string
     const INSDescription := "Enable the implicit lookup of classes defined in assemblies with an Implicit Namespace attribute (/ins)" as string
     const LBDescription := "Allow property access and method calls on expressions of type OBJECT and USUAL (/lb)" as string
-    const NamedArgDescription := "Allow named arguments (Default = FALSE for the Core dialect and TRUE for the other dialects). Changing the dialect may also automatically change this setting. (/namedargs)" as string
+    const NamedArgDescription := "Allow named arguments (Default = TRUE for the Core dialect and FALSE for the other dialects). Changing the dialect may also automatically change this setting. (/namedargs)" as string
     const NSDescription := "Prefix all classes that do not have a namespace prefix and are not in a begin namespace ... end namespace block with the namespace of the assembly (/ns:<Namespace>)" as string
     const OVFDescription := "Check for Overflow and Underflow for numeric expressions, like the CHECKED keyword. (/ovf)" as string
     const UnsafeDescription := "Allow Unsafe code inside this assembly (/unsafe)" as string


### PR DESCRIPTION
The `namedargs` compiler flag seems to be incorrectly described in Visual Studio.

I tried to find all references to this in the code to update them.

## Additional Details

I created a blank X# Console Application (Core Dialect) and the 'Allow Named Arguments' option was checked by default.
(I also created a fresh Console Application using a different dialect and the 'Allow Named Arguments' option was unchecked by default.)
![image](https://github.com/X-Sharp/XSharpPublic/assets/109976286/deac8a34-52c0-4f74-a0aa-72dc3b1b11de)

This is in line with the description in the docs ([GitHub link](https://github.com/X-Sharp/XSharpPublic/blob/main/docs/Help/Topics/opt-namedargs.xml))
![image](https://github.com/X-Sharp/XSharpPublic/assets/109976286/ec2a07b7-a281-447c-8278-4fe9c5a7a188)
