### PR TITLE
Update USUAL ! operator to attempt type cast

### DIFF
--- a/src/Runtime/XSharp.RT/Types/Usual.prg
+++ b/src/Runtime/XSharp.RT/Types/Usual.prg
@@ -1359,13 +1359,13 @@ PUBLIC STRUCTURE __Usual IMPLEMENTS IConvertible, ;
 
 #region Unary Operators
     /// <include file="RTComments.xml" path="Comments/Operator/*" />
-    /// <remarks>This operator is only supported on usuals of type LOGIC.</remarks>
+    /// <remarks>This operator attempts to cast the usual to type LOGIC.</remarks>
     [NODEBUG];
     STATIC OPERATOR !(u AS __Usual) AS LOGIC
         IF u:_usualType == __UsualType.Logic
             RETURN !u:_logicValue
         ENDIF
-        THROW UnaryError("!", u)
+        RETURN !(LOGIC)u
 
     /// <include file="RTComments.xml" path="Comments/Operator/*" />
     /// <remarks>This operator is only supported on usuals of integral types.</remarks>


### PR DESCRIPTION
## Background

It is possible to implicitly cast a `USUAL` to a `LOGIC` value but not possible to apply the not (`!`) operator.
This seems counter intuitive as in one case the `USUAL` can be treated as though it is a `LOGIC` but not in the other case.

I think it would feel more consistent to attempt to implicitly cast the 

## Example
![image](https://github.com/user-attachments/assets/3946fdc6-b1a2-45c4-86f5-1f7d218a1529)

![image](https://github.com/user-attachments/assets/101fad7c-cf68-435b-8a03-b2c69bcec349)

Both giving
![image](https://github.com/user-attachments/assets/90a0bd84-b083-4d19-97fc-0770780d8d97)

## Details

The change to the runtime should make no impact on performance for the happy path (unchanged so there should be no overhead with casting)
It will allow `USUAL` of type [] to be treated a `LOGIC`
It will change the exception for the other `USUAL` types

![image](https://github.com/user-attachments/assets/4ca262e5-d594-4268-97fe-86ce0e11c10f)

I'm happy for this PR to be closed without merging if you think the current behaviour is preferable.