### PR TITLE
When a classlibrary name contains a dot, eg: lib.base.vcx, the last s…

### DIFF
--- a/src/Tools/VFPXPorter/Source/VFPXPorterLib/XPorterCtrlForm.prg
+++ b/src/Tools/VFPXPorter/Source/VFPXPorterLib/XPorterCtrlForm.prg
@@ -935,8 +935,8 @@ BEGIN NAMESPACE VFPXPorterLib
 //             ENDIF
             // Create the File based on the Form Name, or the scx file in case of trouble...
             LOCAL destFile AS STRING
-            destFile := Path.Combine(SELF:Settings:OutputPath, outFileName )
-            destFile := Path.ChangeExtension( destFile, "prg")
+            destFile := Path.Combine(SELF:Settings:OutputPath, outFileName ) + ".prg"
+            //destFile := Path.ChangeExtension( destFile, "prg")
             RETURN destFile
         END METHOD
 


### PR DESCRIPTION
When a classlibrary name contains a dot, eg: lib.base.vcx, the last statement in GetOutputFilename method would change the .base part to .prg what results in a filename lib.prg instead of lib.base_someclass.prg

Since the outFileName value does not contain an extension, the Path.ChangeExtension is not needed.
Just add the .prg extension to the Path.Combine output (or maybe to the outFileName variable inside the Path.Combine call).