### PR TITLE
VFP Runtime: Implemented AMEMBERS() for native objects (nInfo 0 and 1)

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/AMembersTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/AMembersTests.prg
@@ -1,0 +1,79 @@
+﻿// AMembersTests.prg
+// Created by    : irwin
+// Creation Date : 1/9/2026 9:57:02 PM
+// Created for   :
+// WorkStation   : IRWINPC
+
+
+USING System
+USING System.Collections.Generic
+USING System.Text
+USING XUnit
+
+BEGIN NAMESPACE XSharp.VFP.Tests
+    // Guinea Pig class for testing
+    CLASS TestObject
+        PUBLIC MyField AS INT
+        PROPERTY MyProp AS STRING AUTO
+        EVENT MyEvent AS EventHandler
+        METHOD MyMethod AS VOID
+            NOP
+        END METHOD
+    END CLASS
+
+    CLASS AMembersTests
+        [Fact, Trait("Category", "AMembers")];
+        METHOD BasicMembersTest AS VOID
+            LOCAL o AS TestObject
+            o := TestObject{}
+
+            LOCAL ARRAY aInfo(1)
+            VAR nCount := AMembers(aInfo, o, 0) // 1D array
+
+            FOR EACH VAR cMember IN aInfo
+                ? cMember
+            NEXT
+
+            Assert.True(nCount > 0)
+            Assert.Equal(nCount, Alen(aInfo, 1))
+
+            Assert.True(AScan(aInfo, "MYFIELD") > 0)
+            Assert.True(AScan(aInfo, "MYPROP") > 0)
+            Assert.True(AScan(aInfo, "MYMETHOD") > 0)
+            Assert.True(AScan(aInfo, "MYEVENT") > 0)
+
+            Assert.True(AScan(aInfo, "GET_MYPROP") == 0)
+        END METHOD
+
+        [Fact, Trait("Category", "AMembers")];
+        METHOD DetailedMembersTest AS VOID
+            LOCAL o AS TestObject
+            o := TestObject{}
+            LOCAL ARRAY aInfo(1)
+
+            // 2D Array (Name and Type)
+            VAR nCount := AMembers(aInfo, o, 1)
+
+            Assert.True(nCount > 0)
+            Assert.Equal(2, (INT)Alen(aInfo, 2))
+
+            // Confirm method
+            VAR nIndex := AScan(aInfo, "MYMETHOD")
+            Assert.True(nIndex > 0)
+            VAR nRow := ASubscript(aInfo, nIndex)
+            Assert.Equal("Method", aInfo[nRow, 2])
+
+            // Confirm property
+            nIndex := AScan(aInfo, "MYPROP")
+            Assert.True(nIndex > 0)
+            nRow := ASubscript(aInfo, nIndex)
+            Assert.Equal("Property", aInfo[nRow, 2])
+
+            // Confirm event
+            nIndex := AScan(aInfo, "MYEVENT")
+            Assert.True(nIndex > 0)
+            nRow := ASubscript(aInfo, nIndex)
+            Assert.Equal("Event", aInfo[nRow, 2])
+        END METHOD
+    END CLASS
+END NAMESPACE // XSharp.VFP.Tests

--- a/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
+++ b/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
@@ -91,6 +91,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AMembersTests.prg" />
     <Compile Include="CopyToTests.prg" />
     <Compile Include="FinancialTests.prg" />
     <Compile Include="SQLStatementTests.prg" />
@@ -106,11 +107,7 @@
     <Compile Include="StringTests.prg" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System">
-      <Name>System</Name>
-      <AssemblyName>System.dll</AssemblyName>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
+    <Reference Include="System" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PreBuildEvent />

--- a/src/Runtime/XSharp.VFP/ArrayFunctions.prg
+++ b/src/Runtime/XSharp.VFP/ArrayFunctions.prg
@@ -8,10 +8,12 @@ USING XSharp.Internal
 USING System.Text.RegularExpressions
 USING System.Collections.Generic
 USING System.Text
+USING System.Reflection
+USING System.Linq
 
 
 INTERNAL FUNCTION FoxALen(a as ARRAY) AS DWORD
-RETURN XSharp.VFP.Functions.ALen( (__FoxArray) a, 0)
+    RETURN XSharp.VFP.Functions.ALen( (__FoxArray) a, 0)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/alen/*" />
 FUNCTION ALen(a AS __FoxArray) AS DWORD
@@ -29,7 +31,7 @@ FUNCTION ALen(a AS __FoxArray, nArrayAttribute AS LONG) AS DWORD
             RETURN 0
         ENDIF
     CASE 0
-            RETURN (DWORD) a:Count
+        RETURN (DWORD) a:Count
     OTHERWISE
         var cMessage := __VfpStr(VFPErrors.VFP_ATTRIBUTE_OUT_OF_RANGE, nameof(nArrayAttribute))
         THROW ArgumentOutOfRangeException { nameof(nArrayAttribute),nArrayAttribute, cMessage}
@@ -42,21 +44,21 @@ FUNCTION __FoxALen(a AS __FoxArray) AS DWORD
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/aelement/*" />
 FUNCTION AElement(ArrayName AS __FoxArray, nRowSubscript AS DWORD) AS USUAL
-   IF ( nRowSubscript > 0 .AND. nRowSubscript <= ArrayName:Rows )
-      RETURN nRowSubscript
-   ENDIF
-   var cMessage := __VfpStr(VFPErrors.VFP_ATTRIBUTE_OUT_OF_RANGE, nameof(nRowSubscript))
-   THROW ArgumentOutOfRangeException { nameof(nRowSubscript),nRowSubscript, cMessage}
+    IF ( nRowSubscript > 0 .AND. nRowSubscript <= ArrayName:Rows )
+        RETURN nRowSubscript
+    ENDIF
+    var cMessage := __VfpStr(VFPErrors.VFP_ATTRIBUTE_OUT_OF_RANGE, nameof(nRowSubscript))
+    THROW ArgumentOutOfRangeException { nameof(nRowSubscript),nRowSubscript, cMessage}
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/aelement/*" />
 FUNCTION AElement(ArrayName AS __FoxArray, nRowSubscript AS DWORD, nColumnSubscript AS DWORD) AS USUAL
     IF ArrayName:MultiDimensional
         IF nRowSubscript == 0 .OR. nRowSubscript >  ArrayName:Rows
-           var cMessage := __VfpStr(VFPErrors.VFP_ATTRIBUTE_OUT_OF_RANGE,nameof(nRowSubscript))
-           THROW ArgumentOutOfRangeException { nameof(nRowSubscript), nRowSubscript, cMessage}
+            var cMessage := __VfpStr(VFPErrors.VFP_ATTRIBUTE_OUT_OF_RANGE,nameof(nRowSubscript))
+            THROW ArgumentOutOfRangeException { nameof(nRowSubscript), nRowSubscript, cMessage}
         ELSEIF nColumnSubscript == 0 .OR. nColumnSubscript > ArrayName:Columns
-           var cMessage := __VfpStr(VFPErrors.VFP_ATTRIBUTE_OUT_OF_RANGE,nameof(nColumnSubscript))
-           THROW ArgumentOutOfRangeException { nameof(nColumnSubscript), nColumnSubscript, cMessage }
+            var cMessage := __VfpStr(VFPErrors.VFP_ATTRIBUTE_OUT_OF_RANGE,nameof(nColumnSubscript))
+            THROW ArgumentOutOfRangeException { nameof(nColumnSubscript), nColumnSubscript, cMessage }
         ENDIF
         nRowSubscript --
         RETURN ( nRowSubscript * ArrayName:Columns ) + nColumnSubscript
@@ -211,9 +213,9 @@ FUNCTION ShowFoxArray ( aPar AS ARRAY , cPrefix := "" AS STRING ) AS VOID
     IF aTest:MultiDimensional
         FOR i := 1 TO ALen ( aTest , 1 )
             FOR j := 1 TO ALen ( aTest , 2 )
-                 //var line := i"{cPrefix}{cLDelim}{AElement ( aTest , i , j )}{cRDelim} {cLDelim}{i},{j}{cRDelim} {aTest[i,j]} {GetElementValueType ( aTest[i,j] )}"
-                 var line := i"{cPrefix}{cLDelim}{i},{j}{cRDelim} = {aTest[i,j]} {GetElementValueType ( aTest[i,j] )}"
-                 QOut(line)
+                //var line := i"{cPrefix}{cLDelim}{AElement ( aTest , i , j )}{cRDelim} {cLDelim}{i},{j}{cRDelim} {aTest[i,j]} {GetElementValueType ( aTest[i,j] )}"
+                var line := i"{cPrefix}{cLDelim}{i},{j}{cRDelim} = {aTest[i,j]} {GetElementValueType ( aTest[i,j] )}"
+                QOut(line)
             NEXT
         NEXT
     ELSE
@@ -223,14 +225,14 @@ FUNCTION ShowFoxArray ( aPar AS ARRAY , cPrefix := "" AS STRING ) AS VOID
         NEXT
     ENDIF
 
-    LOCAL FUNCTION GetElementValueType( uValue AS USUAL ) AS STRING
-        IF IsNil ( uValue )
-            RETURN "(Nil)"
-        ELSE
-            RETURN "(" + ValType ( uValue ) + ")"
-        ENDIF
+LOCAL FUNCTION GetElementValueType( uValue AS USUAL ) AS STRING
+    IF IsNil ( uValue )
+        RETURN "(Nil)"
+    ELSE
+        RETURN "(" + ValType ( uValue ) + ")"
+    ENDIF
 
-        END FUNCTION
+END FUNCTION
 
 RETURN
 
@@ -272,12 +274,12 @@ FUNCTION ALines (ArrayName AS ARRAY, cExpression AS STRING, nFlags := 0 AS INT, 
         ENDIF
     NEXT
 
-    VAR regexOptions := RegexOptions.None
+    VAR @@regexOptions := RegexOptions.None
     IF lIgnoreCase
-        regexOptions := RegexOptions.IgnoreCase
+        @@regexOptions := RegexOptions.IgnoreCase
     ENDIF
 
-    VAR aRawParts := Regex.Split(cExpression, sbPattern:ToString(), regexOptions)
+    VAR aRawParts := Regex.Split(cExpression, sbPattern:ToString(), @@regexOptions)
 
     VAR finalLines := List<STRING>{}
     VAR nIndex := 0
@@ -322,6 +324,101 @@ FUNCTION ALines (ArrayName AS ARRAY, cExpression AS STRING, nFlags := 0 AS INT, 
     FOR VAR i := 0 TO (INT)nRows - 1
         ArrayName[i + 1] := finalLines[i]
     NEXT
+
+    RETURN nRows
+END FUNCTION
+
+/// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/amembers/*" />
+FUNCTION AMembers (ArrayName AS ARRAY, oObjectOrClass AS USUAL, nArrayContentsID := 0 AS INT, cFlags := "" AS STRING) AS DWORD
+    LOCAL oType AS Type
+
+    IF IsObject(oObjectOrClass)
+        oType := ((OBJECT)oObjectOrClass):GetType()
+    ELSEIF IsString(oObjectOrClass)
+        VAR cName := (STRING)oObjectOrClass
+        oType := Type.GetType(cName, FALSE, TRUE) // Case insensitive
+
+        IF oType == NULL
+            // TODO(irwin): serach in loaded assemblies if not found directly
+            RETURN 0
+        ENDIF
+    ELSE
+        RETURN 0
+    ENDIF
+
+    VAR bFlags := BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy
+    VAR @@aMembers := oType:GetMembers(bFlags)
+
+    VAR resultList := List<STRING[]>{}
+
+    FOREACH VAR oMember IN @@aMembers
+        LOCAL cMemberName AS STRING
+        LOCAL cMemberType AS STRING
+        LOCAL lAdd := FALSE AS LOGIC
+
+        cMemberName := oMember:Name:ToUpper()
+        cMemberType := ""
+
+        IF cMemberName:StartsWith("GET_") .OR. cMemberName:StartsWith("SET_") .OR. ;
+            cMemberName:StartsWith("ADD_") .OR. cMemberName:StartsWith("REMOVE_")
+            LOOP
+        ENDIF
+
+        SWITCH oMember:MemberType
+        CASE MemberTypes.Property
+        CASE MemberTypes.Field
+            cMemberType := "Property"
+            lAdd := TRUE
+
+        CASE MemberTypes.Method
+            cMemberType := "Method"
+            lAdd := TRUE
+
+        CASE MemberTypes.Event
+            cMemberType := "Event"
+            lAdd := TRUE
+
+        CASE MemberTypes.NestedType
+            NOP
+        END SWITCH
+
+        IF lAdd
+            VAR exists := resultList:Any({ x => x[1] == cMemberName })
+            IF !exists
+                resultList:Add( <STRING>{ cMemberName, cMemberType })
+            ENDIF
+        ENDIF
+    NEXT
+
+    // Foxpro sorts it alphabetically
+    resultList:Sort({ x, y => String.Compare(x[1], y[1]) })
+
+    VAR nRows := (DWORD)resultList:Count
+    IF nRows == 0
+        RETURN 0
+    ENDIF
+
+    IF ArrayName IS __FoxArray VAR foxArray
+        IF nArrayContentsID == 0
+            // 1 dimension: Just name
+            foxArray:Resize((INT)nRows) // 1D
+            FOR VAR i := 0 TO (INT)nRows - 1
+                foxArray[i+1] := resultList[i][1]
+            NEXT
+        ELSEIF nArrayContentsID == 1
+            // 2 dimensions: Name and Type
+            foxArray:ReDim(nRows, 2) // 2D
+            FOR VAR i := 0 TO (INT)nRows - 1
+                foxArray[i+1, 1] := resultList[i][1] // Col 1: Name
+                foxArray[i+1, 2] := resultList[i][2] // Col 2: Type
+            NEXT
+        ELSE
+            // nInfo 2, 3 not supported yet
+            THROW NotImplementedException{"AMEMBERS with nInfo=" + nArrayContentsID:ToString() + " is not fully implemented yet."}
+        ENDIF
+    ELSE
+        THROW ArgumentException{"ArrayName must be a valid VFP Array created with DIMENSION or generic usage."}
+    ENDIF
 
     RETURN nRows
 END FUNCTION

--- a/src/Runtime/XSharp.VFP/Defines.prg
+++ b/src/Runtime/XSharp.VFP/Defines.prg
@@ -1497,3 +1497,10 @@ DEFINE ALINES_INCLUDE_LAST := 2
 DEFINE ALINES_NO_EMPTY := 4
 DEFINE ALINES_CASE_IGNORE := 8
 DEFINE ALINES_INCLUDE_SEP := 16
+
+//
+// AMEMBERS() Constants
+//
+DEFINE AMEMBERS_PROPERTIES := 1 // Properties only
+DEFINE AMEMBERS_USER := 2 // User-defined members only (Hard to distinguish in .NET sometimes)
+DEFINE AMEMBERS_METHODS := 3 // Methods and Events only

--- a/src/Runtime/XSharp.VFP/ToDo-A.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-A.prg
@@ -28,12 +28,6 @@ FUNCTION AGetFileVersion (ArrayName, cFileName)
     //RETURN 0
 
 /// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/amembers/*" />
-FUNCTION AMembers (ArrayName, oObjectNameOrClassName , nArrayContentsID , cFlags)
-    THROW NotImplementedException{}
-    //RETURN 0
-
-/// <summary>-- todo --</summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/anetresources/*" />
 FUNCTION ANetResources (ArrayName, cNetworkName, nResourceType)
     THROW NotImplementedException{}


### PR DESCRIPTION
Hi Team,

In this PR I have implemented the first version of `AMEMBERS()` function.

### Implementation details:
- **Scope:** Supports Native X# Objects.
- **Modes:** Implements `nArrayContentsID` modes **0** (1D Array, Names only) and **1** (2D Array, Name + Type).
- **Reflection:** Uses .NET Reflection to discover Properties, Methods, Fields, and Events.
- **Output:** Returns uppercase member names, sorted alphabetically, consistent with VFP behavior.
- **Handling:** Correctly handles `__FoxArray` resizing for both 1D and 2D results.

### Limitations (Phase 2):
- **COM Objects:** `nArrayContentsID = 3` is not yet implemented.
- **Filters:** `cFlags` filtering (e.g., distinguishing "Native" vs "User Defined") is currently ignored (returns all public members)

### Tests:
- Added `AMembersTests.prg` in the test project.
- Verified functionality using a test class with properties, method, and events.
- Validated array structure using `ASubscript()` logic for 2D navigation.
