### PR TITLE
Nuget Package script and Defs modifications to support multiple TFM

### DIFF
--- a/src/Runtime/Nuget/XSPackNuget.prgx
+++ b/src/Runtime/Nuget/XSPackNuget.prgx
@@ -4,64 +4,98 @@ USING System.Linq
 USING System.Text
 USING System.Diagnostics
 
+// What XSharp package are we building ?
 VAR Tool := ""
 IF Args:Count >= 1
 	Tool := Args[0]
 ENDIF
 
+// Per default, XSharp root is three levels up ( we are in src/runtime/Nuget)
 VAR Root := "..\..\.."
+// Create the packages with the Release
 VAR Build := "Release"
+VAR TFM = "Net46+Net8.0"
+// The version file is in src\Common
 VAR VersionFile := Root + "\src\Common\BuildNumber.h"
-
+// Per default, Retrieve the version number
 VAR Version := GetBuildNumber( VersionFile )
 
+// Parameter for Build ?
 IF Args:Count >= 2
 	Build := Args[1]
 ENDIF
 
-VAR SourceFolder := Root + "\Artifacts\" + Build
+// For a Single TFM, this could work
+VAR SourceFolders := Root + "\Artifacts\" + Build
 VAR OutputFolder := Root + "\Artifacts\Packages\" + Build
 
+// Parameter for TFM ?
 IF Args:Count >= 3
-	SourceFolder := Args[2]
+	TFM := Args[2]
 ENDIF
+VAR TfmCount := TFM:Count( { c => c == '+' } )
+// Parameter for SourceFolder, OutputFolder, Version ?
 IF Args:Count >= 4
-	OutputFolder := Args[3]
+	SourceFolders := Args[3]
+ENDIF
+// If you pass some SourceFolders, check if the count match the TFM count
+VAR srcCount := SourceFolders:Count( { c => c == '+' } )
+IF srcCount > 0 .AND. srcCount != TfmCount
+	ErrorMessage( "The number of SourceFolders must match the number of TFM specified." )
+	Tool := ""
+ELSE
+	// Adjust SourceFolders if multiple TFM
+	IF TfmCount >= 1
+		SourceFolders := ""
+		VAR tfmList := TFM:Split( '+' )
+		FOREACH VAR tfmItem IN tfmList
+			IF SourceFolders != ""
+				SourceFolders += "+"
+			ENDIF
+			SourceFolders += Root + "\Artifacts\" + Build + "\" + tfmItem
+		NEXT
+	ENDIF
 ENDIF
 IF Args:Count >= 5
-	Version := Args[4]
+	OutputFolder := Args[4]
+ENDIF
+IF Args:Count >= 6
+	Version := Args[5]
 ENDIF
 
 IF String.IsNullOrEmpty( Tool )
-	Console.WriteLine( "Usage : XSPackNuget <Tool> [ <Build> [ <SourceFolder> [ <OutputFolder> [<VersionNumber>] ] ] ] " )
-    Console.WriteLine( "<Tool> should be Core, RT, VOSDK, VO, VFP, XPP")
-    Console.WriteLine( "<Build> indicate the Build version to use. Release per default.")
-	Console.WriteLine( "<SourceFolder> indicate the Path where files are stored. Artifacts\<Build> per default")
-	Console.WriteLine( "<OutputFolder> indicate the Path where the packages are generated. Artifacts\Packages\<Build> per default")
-	Console.WriteLine( "<VersionNumber> indicate the version of the package to generate. Using current version number per default.")
+	InfoMessage( "Usage : XSPackNuget <Tool> [ <Build> [ <Tfm> [ <SourceFolder> [ <OutputFolder> [<VersionNumber>] ] ] ] ] " )
+    InfoMessage( "<Tool> should be Core, RT, VOSDK, VO, VFP, XPP")
+    InfoMessage( "<Build> indicate the Build version to use. Release per default.")
+	InfoMessage( "<Tfm> indicate the Target Framework. Net46, Net80 or Net46+Net80. Net46+Net80 per default.")
+	InfoMessage( "<SourceFolder> indicate the Path where files are stored. Artifacts\<Build>\<Tfm> per default")
+	InfoMessage( "   For a single Tfm, indicate one source. For 2 Tfm, indicate two folders separated with a '+' sign. Artifacts\<Build>\<Tfm1>+Artifacts\<Build>\<Tfm2>")
+	InfoMessage( "<OutputFolder> indicate the Path where the packages are generated. Artifacts\Packages\<Build> per default")
+	InfoMessage( "<VersionNumber> indicate the version of the package to generate. Using current version number per default.")
 	RETURN
 ENDIF
 
-Console.WriteLine( "Running XSPackNuget ..." )
-Console.WriteLine( "Tool : " + Tool )
-Console.WriteLine( "Build : " + Build )
-Console.WriteLine( "Source Folder : " + SourceFolder )
-Console.WriteLine( "Output Folder : " + OutputFolder )
-Console.WriteLine( "Version : " + Version )
-//
+InfoMessage( "Running XSPackNuget ..." )
+InfoMessage( "Tool : " + Tool )
+InfoMessage( "Build : " + Build )
+InfoMessage( "Target Framework : " + TFM )
+InfoMessage( "Source Folder : " + SourceFolders )
+InfoMessage( "Output Folder : " + OutputFolder )
+InfoMessage( "Version : " + Version )
+// Check if Nuget is installed
 var result := CheckNuGet()
 IF ( ! result )
-    Console.WriteLine( "The application 'Microsoft.NuGet' is NOT installed." )
-    Console.WriteLine( "Please run : winget install Microsoft.NuGet" )
+    ErrorMessage( "The application 'Microsoft.NuGet' is NOT installed." )
+    InfoMessage( "Please run : winget install Microsoft.NuGet" )
     RETURN
 ENDIF
 
-CreateNuSpec( SourceFolder, Tool, Version )
+CreateNuSpec( TFM, SourceFolders, Tool, Version )
 
 IF !RunNuget( Tool, Version, OutputFolder )
-	Console.WriteLine( "Something went wrong...." )
+	ErrorMessage( "Something went wrong...." )
 ENDIF
-Console.WriteLine( "Done." )
+InfoMessage( "Done." )
 
 FUNCTION GetBuildNumber( versionFile AS STRING ) AS String
 	VAR version := "3.0.0"
@@ -102,15 +136,30 @@ FUNCTION CheckNuGet() AS LOGIC
 	END USING
 RETURN result
 
-PROCEDURE CreateNuSpec( sourceFolder AS STRING, tool AS String, version AS STRING )
+PROCEDURE CreateNuSpec( tfm AS STRING, sourceFolders AS STRING, tool AS String, version AS STRING )
 	VAR source := "XSharp." + tool + ".nuspec.txt"
 	VAR destination := "XSharp." + tool + "." + version +".nuspec"
 	VAR content := ""
+	VAR tfmList := tfm:Split('+')
+	VAR sourceFolder := sourceFolders:Split('+')
 	//
-	content := File.ReadAllText( source )
-	content := content:Replace( "$SourceFolder", sourceFolder )
-	content := content:Replace( "$Version", version )
-	File.WriteAllText( destination, content )
+	IF File.Exists( source )
+		VAR contentLines = File.ReadAllLines( source )
+		FOREACH VAR line IN contentLines
+			IF line:Contains( "$SourceFolder" ) // We MUST also have a $TFM tag on the same line
+				FOR VAR i := 1 TO tfmList:Length
+					VAR tfmItem := tfmList[i]
+					VAR srcFolder := sourceFolder[i]
+					content += line:Replace( "$SourceFolder", srcFolder ):Replace( "$TFM", tfmItem ) + Environment.NewLine
+				NEXT
+			ELSE
+				content += line:Replace( "$Version", version ) + Environment.NewLine
+			ENDIF
+		NEXT
+		File.WriteAllText( destination, content )
+	ELSE
+		ErrorMessage( "NuSpec template file not found : " + source )
+	ENDIF
 	//
 RETURN
 
@@ -131,8 +180,23 @@ FUNCTION RunNuget( tool AS String, version AS STRING, outputDirectory AS STRING 
 			var execResult := reader:ReadToEnd()
 			success := execResult:Contains( nupkg )
 			IF !success
-				Console.WriteLine( execResult )
+				ErrorMessage( execResult )
 			ENDIF
 		END USING
 	END USING
 RETURN success
+
+FUNCTION ErrorMessage( msg AS STRING ) AS VOID
+	VAR clr = Console.ForegroundColor
+	Console.ForegroundColor = ConsoleColor.Red
+	Console.WriteLine( msg )
+	Console.ForegroundColor = clr
+	RETURN
+
+FUNCTION InfoMessage( msg AS STRING ) AS VOID
+	VAR clr = Console.ForegroundColor
+	Console.ForegroundColor = ConsoleColor.White
+	Console.WriteLine( msg )
+	Console.ForegroundColor = clr
+	RETURN
+

--- a/src/Runtime/Nuget/XSharp.Core.nuspec.txt
+++ b/src/Runtime/Nuget/XSharp.Core.nuspec.txt
@@ -7,21 +7,17 @@
     <authors>XSharp B.V.</authors>
     <owners>XSharp B.V.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0</license>
     <icon>icon\Xsharp.png</icon>
-	  <readme>Readme.md</readme>
+    <readme>Readme.md</readme>
     <description>XSharp Core</description>
     <copyright>Copyright (C) 2015 and beyond by XSharp B.V.</copyright>
-	<tags>XSharp, Core</tags>
+    <tags>XSharp, Core</tags>
     <repository type="git" url="https://github.com/X-Sharp/XSharpPublic.git" />
-	<dependencies>
-      <group targetFramework=".NETFramework4.6">
-      </group>
-    </dependencies>
   </metadata>
   <files>
     <file src="icon\Xsharp.png" target="icon\Xsharp.png" />
     <file src="Readme.Core.md"  target="Readme.md" />
-    <file src="$SourceFolder\XSharp.Core.dll" target="lib\net46\XSharp.Core.dll" />
+    <file src="$SourceFolder\XSharp.Core.dll" target="lib\$TFM\XSharp.Core.dll" />
   </files>
 </package>

--- a/src/Runtime/Nuget/XSharp.RT.nuspec.txt
+++ b/src/Runtime/Nuget/XSharp.RT.nuspec.txt
@@ -7,26 +7,21 @@
     <authors>XSharp B.V.</authors>
     <owners>XSharp B.V.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0</license>
     <icon>icon\Xsharp.png</icon>
-	  <readme>Readme.md</readme>
+    <readme>Readme.md</readme>
     <description>XSharp Runtime</description>
     <copyright>Copyright (C) 2015 and beyond by XSharp B.V.</copyright>
     <tags>XSharp, Runtime</tags>
     <repository type="git" url="https://github.com/X-Sharp/XSharpPublic.git" />
-	<dependencies>
-      <group targetFramework=".NETFramework4.6">
-        <dependency id="XSharp.Core" version="$Version" />
-      </group>
-    </dependencies>
   </metadata>
   <files>
     <file src="icon\Xsharp.png" target="icon\Xsharp.png" />
     <file src="Readme.RT.md"  target="Readme.md" />
-    <file src="$SourceFolder\XSharp.MacroCompiler.dll" target="lib\net46\XSharp.MacroCompiler.dll" />
-    <file src="$SourceFolder\XSharp.RDD.dll" target="lib\net46\XSharp.RDD.dll" />
-    <file src="$SourceFolder\XSharp.RT.dll" target="lib\net46\XSharp.RT.dll" />
-    <file src="$SourceFolder\XSharp.Data.dll" target="lib\net46\XSharp.Data.dll" />
-    <file src="$SourceFolder\XSharp.RT.Debugger.dll" target="lib\net46\XSharp.RT.Debugger.dll" />
+    <file src="$SourceFolder\XSharp.MacroCompiler.dll" target="lib\$TFM\XSharp.MacroCompiler.dll" />
+    <file src="$SourceFolder\XSharp.RDD.dll" target="lib\$TFM\XSharp.RDD.dll" />
+    <file src="$SourceFolder\XSharp.RT.dll" target="lib\$TFM\XSharp.RT.dll" />
+    <file src="$SourceFolder\XSharp.Data.dll" target="lib\$TFM\XSharp.Data.dll" />
+    <file src="$SourceFolder\XSharp.RT.Debugger.dll" target="lib\$TFM\XSharp.RT.Debugger.dll" />
   </files>
 </package>

--- a/src/Runtime/Nuget/XSharp.VFP.nuspec.txt
+++ b/src/Runtime/Nuget/XSharp.VFP.nuspec.txt
@@ -7,23 +7,18 @@
     <authors>XSharp B.V.</authors>
     <owners>XSharp B.V.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0</license>
     <icon>icon\Xsharp.png</icon>
-	  <readme>Readme.md</readme>
+    <readme>Readme.md</readme>
     <description>XSharp Visual FoxPro Runtime</description>
     <copyright>Copyright (C) 2015 and beyond by XSharp B.V.</copyright>
     <tags>XSharp, VFP, Runtime</tags>
     <repository type="git" url="https://github.com/X-Sharp/XSharpPublic.git" />
-	<dependencies>
-      <group targetFramework=".NETFramework4.6">
-        <dependency id="XSharp.RT" version="$Version" />
-      </group>
-    </dependencies>
   </metadata>
   <files>
     <file src="icon\Xsharp.png" target="icon\Xsharp.png" />
     <file src="Readme.VFP.md"  target="Readme.md" />
-    <file src="$SourceFolder\XSharp.VFP.dll" target="lib\net46\XSharp.VFP.dll" />
-    <file src="$SourceFolder\XSharp.VFP.UI.dll" target="lib\net46\XSharp.VFP.UI.dll" />
+    <file src="$SourceFolder\XSharp.VFP.dll" target="lib\$TFM\XSharp.VFP.dll" />
+    <file src="$SourceFolder\XSharp.VFP.UI.dll" target="lib\$TFM\XSharp.VFP.UI.dll" />
   </files>
 </package>

--- a/src/Runtime/Nuget/XSharp.VO.nuspec.txt
+++ b/src/Runtime/Nuget/XSharp.VO.nuspec.txt
@@ -7,22 +7,17 @@
     <authors>XSharp B.V.</authors>
     <owners>XSharp B.V.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0</license>
     <icon>icon\Xsharp.png</icon>
-	  <readme>Readme.md</readme>
+    <readme>Readme.md</readme>
     <description>XSharp Visual Objects Runtime</description>
     <copyright>Copyright (C) 2015 and beyond by XSharp B.V.</copyright>
     <tags>XSharp, VO, Runtime</tags>
     <repository type="git" url="https://github.com/X-Sharp/XSharpPublic.git" />
-	<dependencies>
-      <group targetFramework=".NETFramework4.6">
-        <dependency id="XSharp.RT" version="$Version" />
-      </group>
-    </dependencies>
   </metadata>
   <files>
     <file src="icon\Xsharp.png" target="icon\Xsharp.png" />
     <file src="Readme.VO.md"  target="Readme.md" />
-    <file src="$SourceFolder\XSharp.VO.dll" target="lib\net46\XSharp.VO.dll" />
+    <file src="$SourceFolder\XSharp.VO.dll" target="lib\$TFM\XSharp.VO.dll" />
   </files>
 </package>

--- a/src/Runtime/Nuget/XSharp.VOSDK.nuspec.txt
+++ b/src/Runtime/Nuget/XSharp.VOSDK.nuspec.txt
@@ -5,8 +5,8 @@
     <version>$Version</version>
     <title>XSharp Visual Objects SDK Classes</title>
     <authors>XSharp B.V.</authors>
-	<owners>XSharp B.V.</owners>
-	<license type="expression">Apache-2.0</license>
+    <owners>XSharp B.V.</owners>
+    <license type="expression">Apache-2.0</license>
     <icon>icon\Xsharp.png</icon>
     <readme>Readme.md</readme>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -14,23 +14,17 @@
     <copyright>Copyright (C) 2015 and beyond by XSharp B.V.</copyright>
     <tags>XSharp, VOSDK</tags>
     <repository type="git" url="https://github.com/X-Sharp/XSharpPublic.git" />
-	
-	<dependencies>
-      <group targetFramework=".NETFramework4.6">
-        <dependency id="XSharp.VO" version="$Version" />
-      </group>
-    </dependencies>
   </metadata>
   <files>
     <file src="icon\Xsharp.png"                 target= "icon\Xsharp.png" />
     <file src="Readme.VOSDK.md"                 target="Readme.md" />
-	  <file src="$SourceFolder\VOConsoleClasses.dll"  target= "lib\net46\VOConsoleClasses.dll" />
-    <file src="$SourceFolder\VORDDClasses.dll" 	    target= "lib\net46\VORDDClasses.dll" 	/>
-    <file src="$SourceFolder\VOSQLClasses.dll" 	    target= "lib\net46\VOSQLClasses.dll" 	/>
-    <file src="$SourceFolder\VOGUIClasses.dll" 	    target= "lib\net46\VOGUIClasses.dll" 	/>
-    <file src="$SourceFolder\VOReportClasses.dll" 	target= "lib\net46\VOReportClasses.dll" 	/>
-    <file src="$SourceFolder\VOSystemClasses.dll" 	target= "lib\net46\VOSystemClasses.dll" 	/>
-    <file src="$SourceFolder\VOWin32APILibrary.dll" target= "lib\net46\VOWin32APILibrary.dll"/>
+	  <file src="$SourceFolder\VOConsoleClasses.dll"  target= "lib\$TFM\VOConsoleClasses.dll" />
+    <file src="$SourceFolder\VORDDClasses.dll" 	    target= "lib\$TFM\VORDDClasses.dll" 	/>
+    <file src="$SourceFolder\VOSQLClasses.dll" 	    target= "lib\$TFM\VOSQLClasses.dll" 	/>
+    <file src="$SourceFolder\VOGUIClasses.dll" 	    target= "lib\$TFM\VOGUIClasses.dll" 	/>
+    <file src="$SourceFolder\VOReportClasses.dll" 	target= "lib\$TFM\VOReportClasses.dll" 	/>
+    <file src="$SourceFolder\VOSystemClasses.dll" 	target= "lib\$TFM\VOSystemClasses.dll" 	/>
+    <file src="$SourceFolder\VOWin32APILibrary.dll" target= "lib\$TFM\VOWin32APILibrary.dll"/>
     <file src="..\voredist\CAPAINT.DLL" 		  target= "content" />
     <file src="..\voredist\CATO3CNT.DLL"          target= "content" />
     <file src="..\voredist\CATO3DAT.DLL"          target= "content" />

--- a/src/Runtime/Nuget/XSharp.XPP.nuspec.txt
+++ b/src/Runtime/Nuget/XSharp.XPP.nuspec.txt
@@ -7,22 +7,17 @@
     <authors>XSharp B.V.</authors>
     <owners>XSharp B.V.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0</license>
     <icon>icon\Xsharp.png</icon>
-	  <readme>Readme.md</readme>
+    <readme>Readme.md</readme>
     <description>XSharp XBase++ Runtime</description>
     <copyright>Copyright (C) 2015 and beyond by XSharp B.V.</copyright>
     <tags>XSharp, XPP, Runtime</tags>
     <repository type="git" url="https://github.com/X-Sharp/XSharpPublic.git" />
-	<dependencies>
-      <group targetFramework=".NETFramework4.6">
-        <dependency id="XSharp.RT" version="$Version" />
-      </group>
-    </dependencies>
   </metadata>
   <files>
     <file src="icon\Xsharp.png" target="icon\Xsharp.png" />
     <file src="Readme.XPP.md"  target="Readme.md" />
-    <file src="$SourceFolder\XSharp.XPP.dll" target="lib\net46\XSharp.XPP.dll" />
+    <file src="$SourceFolder\XSharp.XPP.dll" target="lib\$TFM\XSharp.XPP.dll" />
   </files>
 </package>


### PR DESCRIPTION
The script, XSPackNuget, now support multiple TFM (Target Framework).
So, we can indicate one TFM, and its sourceFolder, or several TFM separated by a '+' (plus sign) respecting the Nuget format, and the corresponding folders also separated by a '+'
Per default: 
- the script generate Nuget Packages for Net46+Net8.0.
- The source folder is Artifacts/_Build_/_TFM_. Per default, Artifacts/Release/Net46 and Artifacts/Release/Net8.0