### PR TITLE
Refactored VFP function names

### DIFF
--- a/src/Runtime/XSharp.VFP/LanguageCoreWrappers.prg
+++ b/src/Runtime/XSharp.VFP/LanguageCoreWrappers.prg
@@ -71,12 +71,12 @@ FUNCTION Abs(nValue IN USUAL) AS USUAL
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/sqrt/*" />
 [FoxProFunction("SQRT", FoxFunctionCategory.MathAndNumeric, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
-FUNCTION Sqrt(nNumber IN USUAL) AS FLOAT
+FUNCTION SQrt(nNumber IN USUAL) AS FLOAT
     RETURN XSharp.RT.Functions.SQrt(nNumber)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/pi/*" />
 [FoxProFunction("PI", FoxFunctionCategory.MathAndNumeric, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
-FUNCTION Pi() AS REAL8
+FUNCTION PI() AS REAL8
     RETURN XSharp.Core.Functions.PI
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/day/*" />
@@ -114,12 +114,12 @@ FUNCTION Chr(dwCode AS DWORD) AS STRING
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/atcline/*" />
 [FoxProFunction("ATCLINE", FoxFunctionCategory.StringAndCharacter, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Medium)];
-FUNCTION AtCLine(cSearch AS STRING, cTarget AS STRING) AS DWORD
+FUNCTION ATCLine(cSearch AS STRING, cTarget AS STRING) AS DWORD
     RETURN XSharp.Core.Functions.ATCLine(cSearch, cTarget)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/atline/*" />
 [FoxProFunction("ATLINE", FoxFunctionCategory.StringAndCharacter, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Medium)];
-FUNCTION AtLine(cSearch AS STRING, cTarget AS STRING) AS DWORD
+FUNCTION ATLine(cSearch AS STRING, cTarget AS STRING) AS DWORD
     RETURN XSharp.Core.Functions.ATLine(cSearch, cTarget)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/padl/*" />
@@ -154,7 +154,7 @@ FUNCTION Replicate(cString AS STRING, dwCount AS DWORD) AS STRING
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/soundex/*" />
 [FoxProFunction("SOUNDEX", FoxFunctionCategory.StringAndCharacter, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
-FUNCTION Soundex(cString AS STRING) AS STRING
+FUNCTION SoundEx(cString AS STRING) AS STRING
     RETURN XSharp.Core.Functions.SoundEx(cString)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/space/*" />
@@ -169,7 +169,7 @@ FUNCTION Stuff(cTarget AS STRING, dwStart AS DWORD, dwDelete AS DWORD, cInsert A
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/substr/*" />
 [FoxProFunction("SUBSTR", FoxFunctionCategory.StringAndCharacter, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION Substr(cTarget AS USUAL, nStart AS USUAL, nCount AS USUAL) AS STRING
+FUNCTION SubStr(cTarget AS USUAL, nStart AS USUAL, nCount AS USUAL) AS STRING
     RETURN XSharp.RT.Functions.SubStr(cTarget, nStart, nCount)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/max/*" />
@@ -199,17 +199,17 @@ FUNCTION Round(nNumber IN USUAL, siDecimals AS INT) AS USUAL
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/acos/*" />
 [FoxProFunction("ACOS", FoxFunctionCategory.MathAndNumeric, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
-FUNCTION Acos(nExpression IN USUAL) AS FLOAT
+FUNCTION ACos(nExpression IN USUAL) AS FLOAT
     RETURN XSharp.RT.Functions.ACos(nExpression)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/asin/*" />
 [FoxProFunction("ASIN", FoxFunctionCategory.MathAndNumeric, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
-FUNCTION Asin(nExpression IN USUAL) AS FLOAT
+FUNCTION ASin(nExpression IN USUAL) AS FLOAT
     RETURN XSharp.RT.Functions.ASin(nExpression)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/atan/*" />
 [FoxProFunction("ATAN", FoxFunctionCategory.MathAndNumeric, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
-FUNCTION Atan(nNum IN USUAL) AS FLOAT
+FUNCTION ATan(nNum IN USUAL) AS FLOAT
     RETURN XSharp.RT.Functions.ATan(nNum)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/atn2/*" />
@@ -234,12 +234,12 @@ FUNCTION Tan(nNum IN USUAL) AS FLOAT
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/dtor/*" />
 [FoxProFunction("DTOR", FoxFunctionCategory.MathAndNumeric, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
-FUNCTION Dtor(nExpression IN USUAL) AS REAL8
+FUNCTION DToR(nExpression IN USUAL) AS REAL8
     RETURN XSharp.RT.Functions.DToR(nExpression)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/rtod/*" />
 [FoxProFunction("RTOD", FoxFunctionCategory.MathAndNumeric, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
-FUNCTION Rtod(nExpression IN USUAL) AS REAL8
+FUNCTION RToD(nExpression IN USUAL) AS REAL8
     RETURN XSharp.RT.Functions.RToD(nExpression)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/exp/*" />
@@ -249,7 +249,7 @@ FUNCTION Exp(nExponent IN USUAL) AS FLOAT
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/log/*" />
 [FoxProFunction("LOG", FoxFunctionCategory.MathAndNumeric, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
-FUNCTION Log(nValue IN USUAL) AS FLOAT
+FUNCTION LOG(nValue IN USUAL) AS FLOAT
     RETURN XSharp.RT.Functions.LOG(nValue)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/log10/*" />
@@ -262,7 +262,7 @@ FUNCTION Log10(nValue IN USUAL) AS FLOAT
 //-----------------------------------------------------------------------*
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/cdow/*" />
 [FoxProFunction("CDOW", FoxFunctionCategory.DateAndTime, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.Medium)];
-FUNCTION CDow(dDate AS DATE) AS STRING
+FUNCTION CDoW(dDate AS DATE) AS STRING
     RETURN XSharp.RT.Functions.CDoW(dDate)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/cmonth/*" />
@@ -272,7 +272,7 @@ FUNCTION CMonth(dDate AS DATE) AS STRING
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/dow/*" />
 [FoxProFunction("DOW", FoxFunctionCategory.DateAndTime, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION Dow(dDate AS DATE) AS DWORD
+FUNCTION DoW(dDate AS DATE) AS DWORD
     RETURN XSharp.RT.Functions.DoW(dDate)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/dmy/*" />
@@ -287,7 +287,7 @@ FUNCTION CToD(cDate AS STRING) AS DATE
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/dtoc/*" />
 [FoxProFunction("DTOC", FoxFunctionCategory.DateAndTime, FoxEngine.RuntimeCore, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION Dtoc(dDate AS DATE) AS STRING
+FUNCTION DToC(dDate AS DATE) AS STRING
     RETURN XSharp.RT.Functions.DToC(dDate)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/fdate/*" />
@@ -365,12 +365,12 @@ FUNCTION Like(sWildCard AS STRING, sSource AS STRING) AS LOGIC
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/memlines/*" />
 [FoxProFunction("MEMLINES", FoxFunctionCategory.StringAndCharacter, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION Memlines(cString AS STRING) AS DWORD
+FUNCTION MemLines(cString AS STRING) AS DWORD
     RETURN XSharp.Core.Functions.MemLines(cString)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/mline/*" />
 [FoxProFunction("MLINE", FoxFunctionCategory.StringAndCharacter, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION Mline(cString AS STRING, nLine AS DWORD, nOffset := 0 AS DWORD) AS STRING
+FUNCTION MLine(cString AS STRING, nLine AS DWORD, nOffset := 0 AS DWORD) AS STRING
     RETURN XSharp.Core.Functions.MLine(cString, nLine)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/objnum/*" />

--- a/src/Runtime/XSharp.VFP/NotSupported.prg
+++ b/src/Runtime/XSharp.VFP/NotSupported.prg
@@ -273,7 +273,7 @@ RETURN NIL
 
 [Obsolete( "This function will not be supported" )];
 [FoxProFunction("PAD", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.NotSupported, FoxCriticality.Medium)];
-FUNCTION PAD( )
+FUNCTION Pad( )
 RETURN NIL
 
 [Obsolete( "This function will not be supported" )];

--- a/src/Runtime/XSharp.VFP/RuntimeCoreWrappers.prg
+++ b/src/Runtime/XSharp.VFP/RuntimeCoreWrappers.prg
@@ -81,7 +81,7 @@ FUNCTION FFlush(nFileHandle AS INT64) AS LOGIC
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/fgets/*" />
 [FoxProFunction("FGETS", FoxFunctionCategory.FileAndIO, FoxEngine.RuntimeCore, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION FGets(nFileHandle AS INT64, nBytes := 254 AS INT) AS STRING
+FUNCTION FGetS(nFileHandle AS INT64, nBytes := 254 AS INT) AS STRING
     RETURN XSharp.Core.Functions.FGetS(nFileHandle, (DWORD) nBytes)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/fopen/*" />
@@ -111,7 +111,7 @@ FUNCTION FOpen(cFileName AS STRING, nAttribute := 0 AS INT) AS INT64
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/fputs/*" />
 [FoxProFunction("FPUTS", FoxFunctionCategory.FileAndIO, FoxEngine.RuntimeCore, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION FPuts(nFileHandle AS INT64, cExpression AS STRING, nBytesWritten := 0 AS INT) AS INT
+FUNCTION FPutS(nFileHandle AS INT64, cExpression AS STRING, nBytesWritten := 0 AS INT) AS INT
     IF nBytesWritten <= 0
         nBytesWritten := (INT) SLen(cExpression)
     ENDIF
@@ -148,17 +148,17 @@ FUNCTION ADir(ArrayName AS ARRAY, cFileSkeleton := "" AS STRING, cAttribute := "
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/diskspace/*" />
 [FoxProFunction("DISKSPACE", FoxFunctionCategory.FileAndIO, FoxEngine.RuntimeCore, FoxFunctionStatus.Stub, FoxCriticality.Low)];
-FUNCTION Diskspace(cDriveName := "" AS STRING, nSpaceType := 1 AS INT) AS REAL8
+FUNCTION DiskSpace(cDriveName := "" AS STRING, nSpaceType := 1 AS INT) AS REAL8
     THROW NotImplementedException{}
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/curdir/*" />
 [FoxProFunction("CURDIR", FoxFunctionCategory.FileAndIO, FoxEngine.RuntimeCore, FoxFunctionStatus.Stub, FoxCriticality.Medium)];
-FUNCTION Curdir(cDriveDesignator := "" AS STRING) AS STRING
+FUNCTION CurDir(cDriveDesignator := "" AS STRING) AS STRING
     THROW NotImplementedException{}
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/os/*" />
 [FoxProFunction("OS", FoxFunctionCategory.EnvironmentAndSystem, FoxEngine.RuntimeCore, FoxFunctionStatus.Stub, FoxCriticality.Low)];
-FUNCTION Os(nType := 0 AS INT) AS STRING
+FUNCTION OS(nType := 0 AS INT) AS STRING
     THROW NotImplementedException{}
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/oemtoansi/*" />

--- a/src/Runtime/XSharp.VFP/UI/UIAndWindows.prg
+++ b/src/Runtime/XSharp.VFP/UI/UIAndWindows.prg
@@ -41,5 +41,5 @@ FUNCTION ChrSaw(nSeconds := 0 AS REAL8) AS LOGIC
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/rgb/*" />
 [FoxProFunction("RGB", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Stub, FoxCriticality.Medium)];
-FUNCTION Rgb(nRedValue AS INT, nGreenValue AS INT, nBlueValue AS INT) AS INT
+FUNCTION RGB(nRedValue AS INT, nGreenValue AS INT, nBlueValue AS INT) AS INT
     THROW NotImplementedException{}

--- a/src/Runtime/XSharp.VFP/WorkAreaWrappers.prg
+++ b/src/Runtime/XSharp.VFP/WorkAreaWrappers.prg
@@ -69,7 +69,7 @@ FUNCTION AFields(ArrayName AS ARRAY, eWorkArea := NIL AS USUAL) AS INT
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/dbf/*" />
 [FoxProFunction("DBF", FoxFunctionCategory.CursorAndTable, FoxEngine.WorkArea, FoxFunctionStatus.Stub, FoxCriticality.High)];
-FUNCTION Dbf(eWorkArea := NIL AS USUAL) AS STRING
+FUNCTION DBF(eWorkArea := NIL AS USUAL) AS STRING
     THROW NotImplementedException{}
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/deleted/*" />
@@ -79,7 +79,7 @@ FUNCTION Deleted(eWorkArea := NIL AS USUAL) AS LOGIC
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/flock/*" />
 [FoxProFunction("FLOCK", FoxFunctionCategory.CursorAndTable, FoxEngine.WorkArea, FoxFunctionStatus.Stub, FoxCriticality.High)];
-FUNCTION FLock(eWorkArea := NIL AS USUAL) AS LOGIC
+FUNCTION Flock(eWorkArea := NIL AS USUAL) AS LOGIC
     THROW NotImplementedException{}
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/rlock/*" />


### PR DESCRIPTION
Refactores VFP function names to match casing in XSharp.Core/RT to ensure .NET compatibility.

## List of functions refactored
1. FLock -> Flock
2. Rgb -> RGB
3. Dbf -> DBF
4. FGets -> FGetS
5. FPuts -> FPutS
6. Diskspace -> DiskSpace
7. Curdir -> CurDir
8. Os -> OS
9. PAD -> Pad
10. Memlines -> MemLines
11. Mline -> MLine
12. Sqrt -> SQrt
13. Pi -> PI
14. AtCLine -> ATCLine
15. AtLine -> ATLine
16. Soundex -> SoundEx
17. Substr -> SubStr
18. Acos -> ACos
19. Asin -> ASin
20. Atan -> ATan
21. Dtor -> DToR
22. Rtod -> RToD
23. Log -> LOG
24. CDow -> CDoW
25. Dow -> DoW
26. Dtoc -> DToC