### PR TITLE
Added support for descending indexes; removed SeekReturnsSubset

### DIFF
--- a/src/Runtime/XSharp.SQLRdd/Classes/Connection.prg
+++ b/src/Runtime/XSharp.SQLRdd/Classes/Connection.prg
@@ -185,8 +185,6 @@ class SqlDbConnection inherit SqlDbHandleObject implements IDisposable
                 self:RecnoColumn := strValue
             case "updateallcolumns"
                 self:UpdateAllColumns := isTrue
-           case "seekreturnssubset"
-                self:SeekReturnsSubset := isTrue
            case "trimtrailingspaces"
                 self:TrimTrailingSpaces := isTrue
             case "usenulls"
@@ -261,7 +259,6 @@ class SqlDbConnection inherit SqlDbHandleObject implements IDisposable
         BufferSize         := DEFAULT_BUFFERSIZE
         DeletedColumn      := DEFAULT_DELETEDCOLUMN
         RecnoColumn        := DEFAULT_RECNOCOLUMN
-        SeekReturnsSubset  := DEFAULT_SEEKRETURNSSUBSET
         cConnectionString  := self:AnalyzeConnectionString(cConnectionString)
         self:ConnectionString := cConnectionString
         DbConnection    := Provider:CreateConnection()
@@ -807,7 +804,6 @@ class SqlDbConnection inherit SqlDbHandleObject implements IDisposable
     INTERNAL CONST DEFAULT_TRIMTRAILINGSPACES := TRUE AS LOGIC
     INTERNAL CONST DEFAULT_UPDATEALLCOLUMNS := FALSE AS LOGIC
     INTERNAL CONST DEFAULT_USENULLS := TRUE AS LOGIC
-    INTERNAL CONST DEFAULT_SEEKRETURNSSUBSET := TRUE AS LOGIC
     INTERNAL CONST DEFAULT_MAXRECNOASRECCOUNT := FALSE AS LOGIC
     #region Events
     /// <summary>

--- a/src/Runtime/XSharp.SQLRdd/Metadata.xh
+++ b/src/Runtime/XSharp.SQLRdd/Metadata.xh
@@ -33,12 +33,6 @@
     /// </summary>
     property RecnoColumn    as string auto
     /// <summary>
-    /// Specifies whether a seek operation should return a subset of the records in the table.
-    /// This defaults to TRUE which means that only the matching rows are returned.
-    /// When FALSE then all rows are returned, and a seek operation positions on the first matching row
-    /// </summary>
-    property SeekReturnsSubset as logic auto
-    /// <summary>
     /// Should trailing spaces for string columns be trimmed?
     /// </summary>
     property TrimTrailingSpaces as logic auto

--- a/src/Runtime/XSharp.SQLRdd/Metadata/Abstract.prg
+++ b/src/Runtime/XSharp.SQLRdd/Metadata/Abstract.prg
@@ -58,6 +58,7 @@ ABSTRACT CLASS SqlMetadataProviderAbstract IMPLEMENTS ISqlMetadataProvider
     INTERNAL CONST DEFAULT_SERVERFILTER := "" AS STRING
     INTERNAL CONST DEFAULT_TAGS:= "" AS STRING
     INTERNAL CONST DEFAULT_UNIQUE:= FALSE AS LOGIC
+    INTERNAL CONST DEFAULT_DESCENDING:= FALSE AS LOGIC
     INTERNAL CONST DEFAULT_UPDATABLECOLUMNS:= "*" AS STRING
     /// <inheritdoc />
     /// <remarks>The abstract implementation does nothing.</remarks>
@@ -83,7 +84,6 @@ ABSTRACT CLASS SqlMetadataProviderAbstract IMPLEMENTS ISqlMetadataProvider
             _connection:RecnoColumn         := SELF:GetString(oPar, SqlRDDEventReason.RecnoColumn, _connection:RecnoColumn)
             _connection:DeletedColumn       := SELF:GetString(oPar, SqlRDDEventReason.DeletedColumn, _connection:DeletedColumn)
             _connection:CompareMemo         := SELF:GetLogic(oPar,  SqlRDDEventReason.CompareMemo, _connection:CompareMemo)
-            _connection:SeekReturnsSubset   := SELF:GetLogic(oPar,  SqlRDDEventReason.SeekReturnsSubset, _connection:SeekReturnsSubset)
             hasDefaults := TRUE
         ENDIF
         RETURN
@@ -102,7 +102,6 @@ ABSTRACT CLASS SqlMetadataProviderAbstract IMPLEMENTS ISqlMetadataProvider
         oTable:RecnoColumn       := SELF:GetString(oPar,  SqlRDDEventReason.RecnoColumn,   _connection:RecnoColumn)
         oTable:TrimTrailingSpaces:= SELF:GetLogic(oPar,   SqlRDDEventReason.TrimTrailingSpaces, _connection:TrimTrailingSpaces)
         oTable:CompareMemo       := SELF:GetLogic(oPar,   SqlRDDEventReason.CompareMemo,   _connection:CompareMemo)
-        oTable:SeekReturnsSubset := SELF:GetLogic(oPar,   SqlRDDEventReason.SeekReturnsSubset,   _connection:SeekReturnsSubset)
         // these fields have no connection level defaults
         oTable:ServerFilter      := SELF:GetString(oPar, SqlRDDEventReason.ServerFilter, DEFAULT_SERVERFILTER)
         oTable:ColumnList        := SELF:GetString(oPar, SqlRDDEventReason.ColumnList, DEFAULT_COLUMNLIST)

--- a/src/Runtime/XSharp.SQLRdd/Metadata/CallBack.prg
+++ b/src/Runtime/XSharp.SQLRdd/Metadata/CallBack.prg
@@ -67,6 +67,7 @@ CLASS SqlMetadataProviderCallBack Inherit SqlMetadataProviderAbstract
         oTag:Expression    := SELF:GetString(cSection, SqlRDDEventReason.Expression , DEFAULT_EXPRESSION)
         oTag:Condition     := SELF:GetString(cSection, SqlRDDEventReason.Condition , DEFAULT_CONDITION)
         oTag:Unique        := SELF:GetLogic(cSection, SqlRDDEventReason.Unique , DEFAULT_UNIQUE)
+        oTag:Descending    := SELF:GetLogic(cSection, SqlRDDEventReason.Descending , DEFAULT_DESCENDING)
         oIndex:Tags:Add(oTag)
         RETURN oTag
     END METHOD

--- a/src/Runtime/XSharp.SQLRdd/Metadata/Database.prg
+++ b/src/Runtime/XSharp.SQLRdd/Metadata/Database.prg
@@ -66,7 +66,6 @@ end class
             _tablecols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.DeletedColumn),"C", 50,0},_connection:DeletedColumn})
             _tablecols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.TrimTrailingSpaces),"L", 1,0},_connection:TrimTrailingSpaces})
             _tablecols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.CompareMemo),"L", 1,0},_connection:CompareMemo})
-            _tablecols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.SeekReturnsSubset),"L", 1,0},_connection:SeekReturnsSubset})
             _tablecols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.UpdatableColumns),"C", 255,0},DEFAULT_UPDATABLECOLUMNS})
             _tablecols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.ColumnList),"C", 255,0},DEFAULT_COLUMNLIST})
             _tablecols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.KeyColumns),"C", 255,0},DEFAULT_KEYCOLUMNS})
@@ -86,6 +85,7 @@ end class
             _indexcols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.Expression)   ,"C", 250,0},DEFAULT_EXPRESSION})
             _indexcols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.Condition)    ,"C", 250,0},DEFAULT_CONDITION})
             _indexcols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.Unique)       ,"L", 1,0},DEFAULT_UNIQUE})
+            _indexcols:Add(MetaFieldInfo{RddFieldInfo{nameof(SqlRDDEventReason.Descending)   ,"L", 1,0},DEFAULT_DESCENDING})
         endif
         RETURN _indexcols
     END METHOD
@@ -271,22 +271,6 @@ end class
                 endif
             endif
 
-                // Check new SeekReturnsSubset field
-
-                cmd:CommandText := i"Select seekreturnssubset from {tableDict}"
-
-                ok := cmd:ExecuteNonQuery(tableDict)
-                if ! ok
-                    var oInfo := RddFieldInfo{nameof(SqlRDDEventReason.SeekReturnsSubset),"L", 1,0}
-                    var colInfo := Connection:Provider:GetSqlColumnInfo(oInfo, Connection)
-                    cmd:CommandText := i"alter table {tableDict} add "+colInfo
-                    ok := cmd:ExecuteNonQuery(tableDict)
-                    if ok
-                        colInfo := Connection:Provider:QuoteIdentifier(oInfo:Name)
-                        cmd:CommandText := i"update {tableDict} set "+colInfo+" = "+Connection:Provider:TrueLiteral
-                        ok := cmd:ExecuteNonQuery(tableDict)
-                    endif
-                endif
             // Read the defaults from the database
             cmd:AddParameter("@p1",DefaultSection)
             cmd:CommandText := i"SELECT * FROM {tableDict} WHERE {nameof(TableName)} = @p1"

--- a/src/Runtime/XSharp.SQLRdd/Metadata/IniFile.prg
+++ b/src/Runtime/XSharp.SQLRdd/Metadata/IniFile.prg
@@ -80,6 +80,7 @@ CLASS SqlMetadataProviderIni Inherit SqlMetadataProviderAbstract
         oTag:Expression    := SELF:GetString(cSection, SqlRDDEventReason.Expression , DEFAULT_EXPRESSION)
         oTag:Condition     := SELF:GetString(cSection, SqlRDDEventReason.Condition , DEFAULT_CONDITION)
         oTag:Unique        := SELF:GetLogic(cSection, SqlRDDEventReason.Unique , DEFAULT_UNIQUE)
+        oTag:Descending    := SELF:GetLogic(cSection, SqlRDDEventReason.Descending , DEFAULT_DESCENDING)
         oIndex:Tags:Add(oTag)
         RETURN oTag
     END METHOD

--- a/src/Runtime/XSharp.SQLRdd/RDD/SQLDbOrderBag.prg
+++ b/src/Runtime/XSharp.SQLRdd/RDD/SQLDbOrderBag.prg
@@ -154,9 +154,11 @@ internal class SqlDbOrderBag INHERIT BaseIndex
         var cExpression := oIni:GetString(section, EXPRESSION, "")
         var cCondition := oIni:GetString(section, CONDITION, "")
         var lUnique     := oIni:GetLogic(section, UNIQUE, FALSE)
+        var lDescending := oIni:GetLogic(section, DESCEND, FALSE)
         oOrder := SqlDbOrder{SELF:RDD,  cTagName, cExpression, SELF}
         oOrder:Condition := cCondition
         oOrder:Unique := lUnique
+        oOrder:Descending   := lDescending
         return oOrder
     end method
 
@@ -181,6 +183,7 @@ internal class SqlDbOrderBag INHERIT BaseIndex
             oIni:WriteString(cPreFix+tag:Name, EXPRESSION, tag:Expression)
             oIni:WriteString(cPreFix+tag:Name, CONDITION, tag:Condition+" ")
             oIni:WriteString(cPreFix+tag:Name, UNIQUE, tag:Unique:ToString())
+            oIni:WriteString(cPreFix+tag:Name, DESCEND, tag:Descending:ToString())
         next
         oIni:WriteString(INDEXPREFIX+SELF:LogicalName, TAGS,cTags)
         return
@@ -219,6 +222,7 @@ internal class SqlDbOrderBag INHERIT BaseIndex
     internal const EXPRESSION  := "Expression" as string
     internal const CONDITION   := "Condition" as string
     internal const UNIQUE      := "Unique" as string
+    internal const DESCEND     := "Descending" as string
 #endregion
 end class
 end namespace // XSharp.RDD.SqlRDD

--- a/src/Runtime/XSharp.SQLRdd/RDD/SQLRDD-Orders.prg
+++ b/src/Runtime/XSharp.SQLRdd/RDD/SQLRDD-Orders.prg
@@ -457,7 +457,7 @@ partial class SQLRDD
         // save PageSize
         var nPageSize := SELF:_oTd:PageSize
         SELF:_oTd:PageSize := 1
-        
+
         if seekInfo:Last
             CurrentOrder:Descending := !CurrentOrder:Descending
         endif
@@ -465,7 +465,7 @@ partial class SQLRDD
         if seekInfo:Last
             CurrentOrder:Descending := !CurrentOrder:Descending
         endif
-        
+
         SELF:_oTd:PageSize := nPageSize
         IF SELF:DataTable:Rows:Count = 0
             RETURN SELF:GoTo(0)
@@ -474,10 +474,8 @@ partial class SQLRDD
 
 
 
-        IF !SELF:_oTd:SeekReturnsSubset
-            var nRec := SELF:RecNo
-            SELF:_GotoRecord(nRec)
-        ENDIF
+        var nRec := SELF:RecNo
+        SELF:_GotoRecord(nRec)
         IF SELF:RowCount > 0
             SELF:_Found := TRUE
             SELF:_SetEOF(FALSE)
@@ -486,13 +484,6 @@ partial class SQLRDD
             SELF:_Found := FALSE
             SELF:_SetEOF(TRUE)
             SELF:_SetBOF(FALSE)
-        ENDIF
-        IF SELF:_oTd:SeekReturnsSubset
-            if seekInfo:Last
-                SELF:RowNumber := SELF:RowCount
-            else
-                SELF:RowNumber := 1
-            endif
         ENDIF
         return true
     end method

--- a/src/Runtime/XSharp.SQLRdd/Support/Enums.prg
+++ b/src/Runtime/XSharp.SQLRdd/Support/Enums.prg
@@ -70,8 +70,8 @@ enum SqlRDDEventReason
     member Condition
 /// <summary>Specifies if the index tag is unique</summary>
     member Unique
-/// <summary>Should a seek return a subset (TRUE) or all rows (FALSE) </summary>
-    member SeekReturnsSubset
+/// <summary>Specifies if the index tag is descending</summary>
+    member Descending
 /// <summary>Retrieve TagName</summary>
     member TagName
 /// <summary>Retrieve Buffersize in pages</summary>

--- a/src/Runtime/XSharp.SQLRdd/Support/Expression.prg
+++ b/src/Runtime/XSharp.SQLRdd/Support/Expression.prg
@@ -244,14 +244,24 @@ internal class SqlDbExpression inherit SqlDbObject
         return sb:ToString()
     access OrderList as List<string>
         local aList as List<string>
+        local cDesc as string
+        local cAsc  as string
+
+        if self:Owner:Descending
+            cDesc   := ""
+            cAsc    := " DESC"
+        else
+            cDesc   := " DESC"
+            cAsc    := ""
+        endif
         if self:Segments:Count > 1
             aList := List<string>{}
             foreach var oSeg in self:Segments
                 foreach var col in oSeg:OrderList
                     if oSeg:Descending
-                        aList:Add(col+" DESC")
+                        aList:Add(col+cDesc)
                     else
-                        aList:Add(col+" ASC")
+                        aList:Add(col+cAsc)
                     endif
                 next
             next
@@ -260,13 +270,15 @@ internal class SqlDbExpression inherit SqlDbObject
             if self:HasFunctions
                 aList := List<string>{} {self:SQLKey}
             else
-                aList := self:ColumnList
+                aList := self:ColumnList:ToList()
             endif
-            if oSeg:Descending
-                for var i := 1 to aList:Count
-                    aList[i] += " DESC"
-                next
-            endif
+            for var i := 0 to aList:Count-1
+                if oSeg:Descending
+                    aList[i] += cDesc
+                else
+                    aList[i] += cAsc
+                endif
+            next
         endif
         return aList
 

--- a/src/Runtime/XSharp.SQLRdd/Support/SqlDbTableCommandBuilder.prg
+++ b/src/Runtime/XSharp.SQLRdd/Support/SqlDbTableCommandBuilder.prg
@@ -67,6 +67,7 @@ internal class SqlDbTableCommandBuilder
                     if !String.IsNullOrEmpty(tag:Condition)
                         oTag:SetCondition(tag:Condition)
                     endif
+                    oTag:Descending := tag:Descending
                     oBag:Add(oTag)
                 next
                 SELF:OrderBagList:Add(oBag)
@@ -198,7 +199,7 @@ internal class SqlDbTableCommandBuilder
         // to calculate the correct pagenumber !
         var currentOrder := _oRdd:CurrentOrder
         var whereClauses := List<String>{}
-        if SELF:_oTable:HasServerFilter .and. !String.IsNullOrEmpty(_oTable:ServerFilter)
+        if SELF:_oTable:HasServerFilter
             whereClauses:Add(_oTable:ServerFilter)
         endif
         if currentOrder != null
@@ -213,9 +214,9 @@ internal class SqlDbTableCommandBuilder
         endif
         var sWhereClause := SELF:CombineWhereClauses(whereClauses)
         sWhereClause := _connection:RaiseStringEvent(_connection, SqlRDDEventReason.WhereClause, _cTable, sWhereClause)
-        
+
         sb:Append(Provider:RowNumberStatement)
-        
+
         // not sure if this is a clever solution,
         // but WhereMacro is already used for nRec
         var cFromWhere := Provider:QuoteIdentifier(self:_oTable:RealName)
@@ -223,11 +224,14 @@ internal class SqlDbTableCommandBuilder
             cFromWhere += SqlDbProvider.WhereClause+sWhereClause
         endif
         sb:Replace(SqlDbProvider.TableNameMacro, cFromWhere)
-        
+
         var cOrderby := Functions.List2String(_oRdd:CurrentOrder:OrderList)
         if SELF:_oTable:HasRecnoColumn
             if ! String.IsNullOrEmpty(cOrderby)
                 cOrderby := cOrderby + ", " + Provider:QuoteIdentifier(self:_oTable:RecnoColumn)
+                if _oRdd:CurrentOrder:Descending
+                    cOrderby += " DESC"
+                endif
             else
                 cOrderby := Provider:QuoteIdentifier(self:_oTable:RecnoColumn)
             endif

--- a/src/Runtime/XSharp.SQLRdd/Support/TableInfo.prg
+++ b/src/Runtime/XSharp.SQLRdd/Support/TableInfo.prg
@@ -150,6 +150,7 @@ class SqlDbTagInfo inherit SqlDbObject
     /// </summary>
     /// <value></value>
     property Index     as SqlDbIndexInfo auto
+    property Descending   as logic  auto
     /// <summary>
     /// Create a new instance of the SqlDbTagInfo class
     /// </summary>


### PR DESCRIPTION
The ‘SeekReturnsSubset’ property has been removed from the code, and the new ‘Descending’ property for index tags has been implemented. The metadata, INI files, callbacks and OrderBag structures have been updated accordingly, so that descending indexes are now supported and correctly taken into account in SQL generation. The SqlRDDEventReason enum now includes ‘Descending’. The logic for seek operations has been simplified.