### PR TITLE
Fix: Add [NeedsAccessToLocals] to VFP Macro Wrappers

### DIFF
--- a/src/Runtime/XSharp.VFP/MacroWrappers.prg
+++ b/src/Runtime/XSharp.VFP/MacroWrappers.prg
@@ -1,0 +1,24 @@
+﻿//
+// Copyright (c) XSharp B.V.  All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+// See License.txt in the project root for license information.
+//
+USING XSharp.Internal
+
+/// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/evaluate/*" />
+[NeedsAccessToLocals(TRUE)];
+[FoxProFunction("EVALUATE", FoxFunctionCategory.General, FoxEngine.Macro, FoxFunctionStatus.Full, FoxCriticality.High)];
+FUNCTION Evaluate(cString AS STRING) AS USUAL
+    RETURN XSharp.RT.Functions.Evaluate(cString)
+
+
+/// <include file="VfpDocs.xml" path="Runtimefunctions/execscript/*" />
+[FoxProFunction("EXECSCRIPT", FoxFunctionCategory.General, FoxEngine.Macro, FoxFunctionStatus.Partial, FoxCriticality.High)];
+FUNCTION ExecScript(cExpression, eParameter1, eParameter2, eParameterN) AS USUAL CLIPPER
+    RETURN XSharp.RT.Functions.ExecScript(cExpression, eParameter1, eParameter2, eParameterN)
+
+/// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/type/*" />
+[NeedsAccessToLocals(FALSE)];
+[FoxProFunction("TYPE", FoxFunctionCategory.General, FoxEngine.NameResolution, FoxFunctionStatus.Full, FoxCriticality.High)];
+FUNCTION Type(cString AS STRING) AS STRING
+    RETURN XSharp.RT.Functions.Type(cString)

--- a/src/Runtime/XSharp.VFP/XSharp.VFP.xsproj
+++ b/src/Runtime/XSharp.VFP/XSharp.VFP.xsproj
@@ -68,6 +68,7 @@
     <Compile Include="GatherScatter.prg" />
     <Compile Include="GetWord.prg" />
     <Compile Include="Keyboard.prg" />
+    <Compile Include="MacroWrappers.prg" />
     <Compile Include="NotSupported.prg" />
     <Compile Include="PrinterFunctions.prg" />
     <Compile Include="RuntimeCoreWrappers.prg" />


### PR DESCRIPTION
Restores `MacroWrappers.prg` in `XSharp.VFP` and applied the `[NeedsAccessToLocals]` attribute where appropriate.