### PR TITLE
[DOCC]update TOC captions, links & fixes

### DIFF
--- a/docs/Help_ZH-CN/Maps/table_of_contents.xml
+++ b/docs/Help_ZH-CN/Maps/table_of_contents.xml
@@ -286,11 +286,11 @@
       <topicref type="topic" id="460575145617501" build="ALL" modified="2026-02-09T14:03:36.266Z" icon="0" href="Known-Issues-in-XSharp-3">
         <caption translate="true">XSharp 3 已知问题</caption>
       </topicref>
-      <topicref type="topic" id="460571586406113" build="ALL" modified="2026-02-09T14:03:59.716Z" icon="0" href="VersionHistoryXSharp2">
-        <caption translate="true">历史XSharp 2</caption>
+      <topicref type="topic" id="460571586406113" build="ALL" modified="2026-03-19T20:10:13.535Z" icon="0" href="VersionHistoryXSharp2">
+        <caption translate="true">历史：XSharp 2</caption>
       </topicref>
-      <topicref type="topic" id="460572396034078" build="ALL" modified="2026-02-09T14:04:13.524Z" icon="0" href="VersionHistoryXSharp1">
-        <caption translate="true">历史 XSharp 1 及更早版本</caption>
+      <topicref type="topic" id="460572396034078" build="ALL" modified="2026-03-19T20:10:31.942Z" icon="0" href="VersionHistoryXSharp1">
+        <caption translate="true">历史：XSharp 1 及更早版本</caption>
       </topicref>
     </topicref>
     <topicref type="topic" id="428984094992566" build="ALL" modified="2024-06-04T08:08:25.825Z" icon="0" href="MigratingappsfromVOtoX">
@@ -313,8 +313,8 @@
     </topicref>
     <topicref type="topic" id="432585631903751" build="ALL" modified="2024-06-04T08:11:26.637Z" icon="0" href="The-X-Runtime">
       <caption translate="true">X# 运行时(Runtime)</caption>
-      <topicref type="topic" id="460576784294169" build="ALL" modified="2026-02-09T14:08:05.130Z" icon="0" href="Nuget-Packages">
-        <caption translate="true">金块套装</caption>
+      <topicref type="topic" id="460576784294169" build="ALL" modified="2026-03-19T19:51:46.347Z" icon="0" href="Nuget-Packages">
+        <caption translate="true">Nuget Packages</caption>
       </topicref>
       <topicref type="topic" id="432589511557658" build="ALL" modified="2018-06-07T17:53:51.735Z" icon="0" href="XSharp_Core">
         <caption translate="true">XSharp.Core</caption>

--- a/docs/Help_ZH-CN/Topics/Installation.xml
+++ b/docs/Help_ZH-CN/Topics/Installation.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="../helpproject.xsl" ?>
-<topic template="Default" modified="2026-02-09T14:16:32.828Z" lasteditedby="robert" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
+<topic template="Default" modified="2026-03-19T19:46:24.144+08:00" lasteditedby="niuji" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
   <title>安装</title>
   <keywords>
     <keyword>component</keyword>
@@ -290,7 +290,7 @@
         <td style="width:666px;">
           <list id="2" type="ul" listtype="bullet" formatstring="&#183;" format-charset="SYMBOL_CHARSET" levelreset="true" legalstyle="false" startfrom="1" styleclass="Normal" style="font-family:Symbol; font-size:11pt; color:#000000;">
             <li styleclass="Normal"><text style="font-weight:bold;">&lt;number&gt; </text>是 2019。</li>
-            <li styleclass="Normal"><text style="font-weight:bold;">&lt;版本&gt; </text>可能为 Professional、Community、Enterprise 或 Buildtools 之一。您的计算机<br/>上可能安装了多个版本的 VS2017/VS2019。安装程序将显示所有检测到的实例。</li>
+            <li styleclass="Normal"><text style="font-weight:bold;">&lt;版本&gt; </text>可能为 Professional、Community、Enterprise 或 Buildtools 之一。您的计算机<br/>上可能安装了多个版本的 VS2019。安装程序将显示所有检测到的实例。</li>
           </list>
         </td>
       </tr>

--- a/docs/Help_ZH-CN/Topics/Nuget-Packages.xml
+++ b/docs/Help_ZH-CN/Topics/Nuget-Packages.xml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="../helpproject.xsl" ?>
-<topic template="Default" modified="2026-02-09T14:08:31.705Z" lasteditedby="robert" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
-  <title>金块套装</title>
+<topic template="Default" modified="2026-03-19T19:51:55.183+08:00" lasteditedby="niuji" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
+  <title>Nuget Packages</title>
   <body>
     <header>
-      <para styleclass="Heading1">金块套装</para>
+      <para styleclass="Heading1">Nuget Packages</para>
     </header>
     <para styleclass="Normal">XSharp 3 随附用于运行时的 NuGet 包。<br/>这些包包含针对 .Net Framework 4.6 和 .Net 8.0 的程序集及支持文件。</para>
     <para styleclass="Normal">具体包如下：</para>

--- a/docs/Help_ZH-CN/Topics/VersionHistory.xml
+++ b/docs/Help_ZH-CN/Topics/VersionHistory.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="../helpproject.xsl" ?>
-<topic template="Default" modified="2026-03-17T11:40:44.371Z" lasteditedby="robert" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
+<topic template="Default" modified="2026-03-19T19:43:21.677+08:00" lasteditedby="niuji" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
   <title>版本历史</title>
   <keywords>
     <keyword>Changes</keyword>
@@ -16,14 +16,14 @@
     <para styleclass="Heading1">3.0.0.2版本变更</para>
     <para styleclass="Heading1"><text styleclass="Heading3">编译器</text></para>
     <list id="0" type="ul" listtype="bullet" formatstring="&#183;" format-charset="SYMBOL_CHARSET" levelreset="true" legalstyle="false" startfrom="1" styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none; font-family:Symbol; font-size:11pt; color:#000000;">
-      <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">修改了RECALL命令的UDC，因为FoxPro在执行该命令期间会暂时关闭SetDeleted()设置（#1838）</text></li>
+      <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">修改了RECALL命令的UDC，因为FoxPro在执行该命令期间会暂时关闭SetDeleted()设置（</text><link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1838" target="_blank" styleclass="Normal">#1838</link><text styleclass="Normal">）</text></li>
     </list>
     <para styleclass="Heading1"><text styleclass="Heading3">运行时</text></para>
     <list id="1" type="ul" listtype="bullet" formatstring="&#183;" format-charset="SYMBOL_CHARSET" levelreset="true" legalstyle="false" startfrom="1" styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none; font-family:Symbol; font-size:11pt; color:#000000;">
       <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">添加了 AUsed() 函数的实现（VFP）</text></li>
-      <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">修复了在两个不同的工作区中打开同一张表时，若文件名仅大小写不同，DBF缓存出现的问题（#1828）</text></li>
-      <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">修复了 FoxPro 表中包含自动编号字段时 DBF 头文件锁定的问题（#1829）</text></li>
-      <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">DBFVFP 驱动程序现支持包含 Trim()、Ltrim()、RTrim() 等函数的索引表达式 (#1837)</text></li>
+      <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">修复了在两个不同的工作区中打开同一张表时，若文件名仅大小写不同，DBF缓存出现的问题（</text><link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1828" target="_blank" styleclass="Normal">#1828</link><text styleclass="Normal">）</text></li>
+      <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">修复了 FoxPro 表中包含自动编号字段时 DBF 头文件锁定的问题（</text><link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1829" target="_blank" styleclass="Normal">#1829</link><text styleclass="Normal">）</text></li>
+      <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">DBFVFP 驱动程序现支持包含 Trim()、Ltrim()、RTrim() 等函数的索引表达式 (</text><link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1837" target="_blank" styleclass="Normal">#1837</link><text styleclass="Normal">)</text></li>
       <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">若干 UI 相关函数（如 MessageBox()）的实现已从 XSharp.VFP 移至 XSharp.VFP.UI。当无法找到 XSharp.VFP.UI 时</text><br/><text styleclass="Normal">，这些函数现在将输出到控制台窗口。</text></li>
       <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">XSharp.VFP 程序集现已包含 VFP 中所有函数的定义，即使这些函数存在于 XSharp.Core 和 XSharp.RT 中。这些函数将把工作委托给其他程序集中的实现。</text></li>
       <li styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none;"><text styleclass="Normal">修复了 .Net 8 宏编译器中的一个问题</text></li>
@@ -45,14 +45,14 @@
     <para styleclass="Heading1"><text styleclass="Heading3">VS集成</text></para>
     <list id="4" type="ul" listtype="bullet" formatstring="&#183;" format-charset="SYMBOL_CHARSET" levelreset="true" legalstyle="false" startfrom="1" styleclass="Normal" style="font-family:Symbol; font-size:11pt; color:#000000;">
       <li styleclass="Normal">&quot;ToggleComment&quot;命令现根据代码块首行的注释状态决定是否对整个代码块进行注释/取消注释。若代码块内某行已注释，执行注释操作后可能导致该行被双重注释；反之，若对包含双重注释行的代码块取消注释，该行将变为单行注释。</li>
-      <li styleclass="Normal">不再向SDK项目添加ProjectGuid属性。同时移除了SDK项目内部引用中的GUID值。(#1819)</li>
-      <li styleclass="Normal">修复了解决方案资源管理器窗口中引用名称重复的问题(#1816)</li>
+      <li styleclass="Normal">不再向SDK项目添加ProjectGuid属性。同时移除了SDK项目内部引用中的GUID值。(<link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1819" target="_blank">#1819</link>)</li>
+      <li styleclass="Normal">修复了解决方案资源管理器窗口中引用名称重复的问题(<link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1816" target="_blank">#1816</link>)</li>
       <li styleclass="Normal">当项目存在多个指向同一外部项目的引用时可能引发问题，现已修复。第二个引用将被（静默）忽略。</li>
-      <li styleclass="Normal">IDE 已为菜单选项做好准备，可将传统项目转换为新的 SDK 项目文件格式（#1823）。该菜单选项目前尚未启用。</li>
-      <li styleclass="Normal">修复了添加程序集引用时偶发的VS崩溃问题(#1814)</li>
+      <li styleclass="Normal">IDE 已为菜单选项做好准备，可将传统项目转换为新的 SDK 项目文件格式（<link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1823" target="_blank">#1823</link>）。该菜单选项目前尚未启用。</li>
+      <li styleclass="Normal">修复了添加程序集引用时偶发的VS崩溃问题(<link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1814" target="_blank">#1814</link>)</li>
     </list>
     <list id="5" type="ul" listtype="bullet" formatstring="&#183;" format-charset="SYMBOL_CHARSET" levelreset="true" legalstyle="false" startfrom="1" styleclass="Normal" style="font-family:Symbol; font-size:11pt; color:#000000;">
-      <li styleclass="Normal">文档格式化器现在会排除属于 TEXT ... ENDTEXT 结构的行 </li>
+      <li styleclass="Normal">文档格式化器现在会排除 TEXT ... ENDTEXT 结构内的代码行 </li>
     </list>
     <para styleclass="Heading1"><text styleclass="Heading3">模板</text></para>
     <list id="0" type="ul" listtype="bullet" formatstring="&#183;" format-charset="SYMBOL_CHARSET" levelreset="true" legalstyle="false" startfrom="1" styleclass="" style="text-align:left; text-indent:-24px; margin-top:0px; margin-right:0px; margin-bottom:0px; margin-left:24px; line-height:1.00; background-color:transparent; white-space:normal; page-break-inside:auto; page-break-after:auto; border:none; tabstops:none; font-family:Symbol; font-size:11pt; color:#000000;">
@@ -69,14 +69,14 @@
     <para styleclass="Heading1"><text styleclass="Heading3">构建系统</text></para>
     <list id="7" type="ul" listtype="bullet" formatstring="&#183;" format-charset="SYMBOL_CHARSET" levelreset="true" legalstyle="false" startfrom="1" styleclass="Normal" style="font-family:Symbol; font-size:11pt; color:#000000;">
       <li styleclass="Normal">修复了由Stefan Hirsch报告的错误，该错误由输出程序集自动添加OSPlatformAttribute引起</li>
-      <li styleclass="Normal">修复了NuGet错误：旧式项目使用包引用时将&quot;win-x86&quot;列为运行时标识符的问题(#1801)</li>
+      <li styleclass="Normal">修复了NuGet错误：旧式项目使用包引用时将&quot;win-x86&quot;列为运行时标识符的问题(<link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1801" target="_blank">#1801</link>)</li>
     </list>
     <para styleclass="Heading1"><text styleclass="Heading3">VS集成</text></para>
     <list id="8" type="ul" listtype="bullet" formatstring="&#183;" format-charset="SYMBOL_CHARSET" levelreset="true" legalstyle="false" startfrom="1" styleclass="Normal" style="font-family:Symbol; font-size:11pt; color:#000000;">
       <li styleclass="Normal">Visual Studio 的输出窗口有时无法显示进度。<br/>此问题已修复（由 Trevor 报告）</li>
-      <li styleclass="Normal">当选中X#项目时，若正在构建其他项目，&quot;构建/取消&quot;按钮不可见（#1799）</li>
-      <li styleclass="Normal">即使在项目属性页选择/nostddef编译器选项后，include-files节点仍可能显示文件。建议触发项目内所有文件以完全刷新（清除）包含列表（#1805）</li>
-      <li styleclass="Normal">修复在VS2026加载项目时出现的&quot;类型初始化器&apos;XSharp.Project.ErrorListManager&apos;抛出异常&quot;错误（#1800）</li>
+      <li styleclass="Normal">当选中X#项目时，若正在构建其他项目，&quot;构建/取消&quot;按钮不可见（<link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1799" target="_blank">#1799</link>）</li>
+      <li styleclass="Normal">即使在项目属性页选择/nostddef编译器选项后，include-files节点仍可能显示文件。建议触发项目内所有文件以完全刷新（清除）包含列表（<link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1805" target="_blank">#1805</link>）</li>
+      <li styleclass="Normal">修复在VS2026加载项目时出现的&quot;类型初始化器&apos;XSharp.Project.ErrorListManager&apos;抛出异常&quot;错误（<link displaytype="text" defaultstyle="true" type="weblink" href="https://github.com/X-Sharp/XSharpPublic/issues/1800" target="_blank">#1800</link>）</li>
       <li styleclass="Normal">语言服务现支持全局USING语法 </li>
       <li styleclass="Normal">更新了Windows Forms和WPF SDK模板</li>
       <li styleclass="Normal">SDK项目自动添加的程序集在属性窗口中显示更多属性。</li>

--- a/docs/Help_ZH-CN/Topics/VersionHistoryXSharp1.xml
+++ b/docs/Help_ZH-CN/Topics/VersionHistoryXSharp1.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="../helpproject.xsl" ?>
-<topic template="Default" modified="2026-02-09T14:04:27.732Z" lasteditedby="robert" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
-  <title>历史 XSharp 1 及更早版本</title>
+<topic template="Default" modified="2026-03-19T20:10:36.351+08:00" lasteditedby="niuji" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
+  <title>历史：XSharp 1 及更早版本</title>
   <keywords>
     <keyword>Changes</keyword>
     <keyword>Runtime chapter</keyword>
@@ -11,7 +11,7 @@
   </keywords>
   <body>
     <header>
-      <para styleclass="Heading1">历史 XSharp 1 及更早版本</para>
+      <para styleclass="Heading1">历史：XSharp 1 及更早版本</para>
     </header>
     <para styleclass="Heading1">Changes in 1.2.1</para>
     <para styleclass="Heading2">编译器</para>

--- a/docs/Help_ZH-CN/Topics/VersionHistoryXSharp2.xml
+++ b/docs/Help_ZH-CN/Topics/VersionHistoryXSharp2.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="../helpproject.xsl" ?>
-<topic template="Default" modified="2026-02-09T14:04:11.913Z" lasteditedby="robert" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
-  <title>历史XSharp 2</title>
+<topic template="Default" modified="2026-03-19T20:10:15.829+08:00" lasteditedby="niuji" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
+  <title>历史：XSharp 2</title>
   <keywords>
     <keyword>Changes</keyword>
     <keyword>Runtime chapter</keyword>
@@ -11,7 +11,7 @@
   </keywords>
   <body>
     <header>
-      <para styleclass="Heading1">历史XSharp 2</para>
+      <para styleclass="Heading1">历史：XSharp 2</para>
     </header>
     <para styleclass="Heading1">Changes in 2.24.0.1</para>
     <para styleclass="Heading1"><text styleclass="Heading2">编译器</text><br/><text styleclass="Heading3">Bug修复</text></para>

--- a/docs/Help_ZH-CN/Topics/Who-is-the-X-team.xml
+++ b/docs/Help_ZH-CN/Topics/Who-is-the-X-team.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="../helpproject.xsl" ?>
-<topic template="Default" modified="2026-02-09T14:20:41.205Z" lasteditedby="robert" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
+<topic template="Default" modified="2026-03-19T20:11:33.414+08:00" lasteditedby="niuji" version="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../helpproject.xsd">
   <title>X# 团队成员</title>
   <body>
     <header>
@@ -77,7 +77,7 @@
           <para styleclass="Body Text">西班牙</para>
         </td>
         <td style="width:187px;">
-          <para styleclass="Body Text">irwin@xsharp.e</para>
+          <para styleclass="Body Text">irwin@xsharp.eu</para>
         </td>
         <td style="width:678px;">
           <para styleclass="Body Text">西班牙语翻译，FoxPro兼容性</para>


### PR DESCRIPTION
Update Chinese help topics and TOC: adjust captions (add punctuation and rename 'Nuget Packages'), add inline GitHub issue links for referenced issue numbers, correct minor text/typo fixes (e.g. VS2019 mention, TEXT...ENDTEXT phrasing), fix an email domain, and update modified/lasteditedby metadata. These changes improve accuracy and linkability of the version-history and runtime documentation.