### PR TITLE
Seek and filter logic in SQLRDD and SqlDbOrder revised

### DIFF
--- a/src/Runtime/XSharp.SQLRdd/RDD/SQLDbOrder.prg
+++ b/src/Runtime/XSharp.SQLRdd/RDD/SQLDbOrder.prg
@@ -205,10 +205,14 @@ internal class SqlDbOrder inherit SqlDbObject
     method SeekExpression(seekInfo as DbSeekInfo) as string
         local cComp as string
         local cWhereClause as string
-        if seekInfo:Last
-            cComp := iif( seekInfo:SoftSeek, " <= ", " = " )
+        if seekInfo:SoftSeek
+            if self:Descending
+                cComp := " <= "
+            else
+                cComp := " >= "
+            endif
         else
-            cComp := iif( seekInfo:SoftSeek, " >= ", " = " )
+            cComp := " = "
         endif
         if seekInfo:Value is string var strValue
             var strLen := strValue:Length

--- a/src/Runtime/XSharp.SQLRdd/RDD/SQLRDD-Main.prg
+++ b/src/Runtime/XSharp.SQLRdd/RDD/SQLRDD-Main.prg
@@ -783,6 +783,19 @@ partial class SQLRDD inherit Workarea
         return super:Pack()
     end method
 
+    OVERRIDE METHOD SetFilter(info AS DbFilterInfo) AS LOGIC
+        var cbFilter := info:FilterBlock
+        if cbFilter != NULL
+            try
+                SELF:EvalFilter(cbFilter)
+            catch ex as Exception
+                SELF:_dbfError(ex, Subcodes.EDB_SETFILTER,Gencode.EG_ARG,"SQLRDD.SetFilter",FALSE)
+                return false
+            end try
+        endif
+        RETURN SUPER:SetFilter(info)
+    end method
+
 end class
 
 end namespace // XSharp.RDD.SqlRDD

--- a/src/Runtime/XSharp.SQLRdd/RDD/SQLRDD-Orders.prg
+++ b/src/Runtime/XSharp.SQLRdd/RDD/SQLRDD-Orders.prg
@@ -457,35 +457,64 @@ partial class SQLRDD
         // save PageSize
         var nPageSize := SELF:_oTd:PageSize
         SELF:_oTd:PageSize := 1
-
-        if seekInfo:Last
-            CurrentOrder:Descending := !CurrentOrder:Descending
-        endif
         self:_OpenTable(cSeekWhere)
-        if seekInfo:Last
-            CurrentOrder:Descending := !CurrentOrder:Descending
-        endif
-
         SELF:_oTd:PageSize := nPageSize
-        IF SELF:DataTable:Rows:Count = 0
-            RETURN SELF:GoTo(0)
+
+        IF SELF:DataTable:Rows:Count = 0 .and. !seekInfo.SoftSeek
+            SELF:GoTo(0)
+            SELF:_Found := false
+            SELF:_SetEOF(true)
+            SELF:_SetBOF(false)
+            return false
         ENDIF
 
+        var nRec   := SELF:RecNo
+        var lFound := SELF:GoTo(nRec)
 
+        if lFound .and.;
+            !SELF:_FilterInfo:Active .and.;
+            !seekInfo.Last
+            SELF:_SetEOF(false)
+            SELF:_SetBOF(false)
+            self:Found := True
+            return true
+        endif
 
+        var uSeek       := seekInfo:Value
+        var cbFilter    := SELF:_FilterInfo:FilterBlock
+        var oDBOI       := DbOrderInfo{}
+        var lData       := false
+        WHILE(!SELF:EoF .AND. !SELF:BoF)
+            if !SELF:_FilterInfo:Active .or. SELF:EvalFilter(cbFilter)
+                if self:KeyCompare(self:OrderInfo(DBOI_KEYVAL,oDBOI),uSeek) = 0
+                    lData   := true
+                    nRec    := self:RecNo
+                    if !seekInfo:Last
+                        exit
+                    endif
+                elseif seekInfo.SoftSeek .and. !lData
+                    nRec := self:RecNo
+                    exit
+                else
+                    exit
+                endif
+            endif
+            self:Skip(1)
+        enddo
+        self:GoTo(nRec)
 
-        var nRec := SELF:RecNo
-        SELF:_GotoRecord(nRec)
-        IF SELF:RowCount > 0
-            SELF:_Found := TRUE
+        IF lFound
             SELF:_SetEOF(FALSE)
             SELF:_SetBOF(FALSE)
+            self:Found  := (self:KeyCompare(self:OrderInfo(DBOI_KEYVAL,oDBOI),uSeek) = 0)
         ELSE
-            SELF:_Found := FALSE
+            SELF:GoTo(0)
             SELF:_SetEOF(TRUE)
             SELF:_SetBOF(FALSE)
+            self:Found := false
         ENDIF
-        return true
+
+        return self:Found
     end method
 
     PRIVATE METHOD KeyCompare(oRecKey as OBJECT, oKey as OBJECT) AS LONG


### PR DESCRIPTION
The SeekExpression method now only handles soft seeks. The search for the last occurrence of a key is handled within the seek logic. The seek logic in SQLRDD-Orders.prg has been fundamentally revised. By evaluating index expressions and filters locally, the result for SoftSeek and SeekLast now more closely resembles the behaviour of DBF. In SQLRDD, SetFilter has been overridden to ensure filter blocks are executed safely and to catch errors.