### PR TITLE
Fix: Convert MemoHelpers.MAX_WIDTH to dynamic property

### DIFF
--- a/src/Runtime/XSharp.Core/Functions/Memo.prg
+++ b/src/Runtime/XSharp.Core/Functions/Memo.prg
@@ -12,7 +12,11 @@ PUBLIC CLASS XSharp.MemoHelpers
     /// <exclude/>
 	CONST END_MEMO   := 0x1A AS INT // ^Z
     /// <exclude/>
-	CONST MAX_WIDTH  := 254 AS INT
+    STATIC PROPERTY MAX_WIDTH AS INT
+        GET
+            RETURN IIF(XSharp.RuntimeState.Dialect == XSharpDialect.FoxPro, 8192, 254)
+        END GET
+    END PROPERTY
     /// <exclude/>
 	CONST TAB		 := 9 AS INT
     /// <exclude/>

--- a/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
@@ -297,6 +297,24 @@ BEGIN NAMESPACE XSharp.VFP.Tests
 
             Set(Set.MemoWidth, nOld)
         END METHOD
+
+        [Fact, Trait("Category", "Database")];
+        METHOD SetMemoWidthExtendedTests() AS VOID
+            VAR nOld := (INT)Set(Set.MemoWidth)
+
+            VAR cLong := "This is a long enough string to have some word wrap"
+
+            Set(Set.MemoWidth, 20)
+            Assert.Equal(3, (INT)MemLines(cLong))
+
+            Set(Set.MemoWidth, 50)
+            Assert.Equal(2, (INT)MemLines(cLong))
+
+            Set(Set.MemoWidth, 256)
+            Assert.Equal(1, (INT)MemLines(cLong))
+
+            Set(Set.MemoWidth, nOld)
+        END METHOD
 	END CLASS
 
 END NAMESPACE


### PR DESCRIPTION
Converted `MemoHelpers.MAX_WIDTH` from constant to statis property. It now returns **8192** when the dialect is set to **FoxPro** and **254** for all other dialects. This enables correct behavior for `SET MEMOWIDTH` in VFP without breaking backward compatibility for VO/Clipper/Vulcan.