### PR TITLE
Fix: MESSAGEBOX() timeout issue and implement dynamic parameter handling

### DIFF
--- a/src/Runtime/XSharp.VFP.UI/AutoCloseMessageBox.prg
+++ b/src/Runtime/XSharp.VFP.UI/AutoCloseMessageBox.prg
@@ -13,7 +13,7 @@ USING System.Runtime.InteropServices
 USING System.Windows.Forms
 
 BEGIN NAMESPACE XSharp.VFP.UI
-
+    [Obsolete];
     INTERNAL CLASS AutoCloseMessageBox
         PRIVATE INITONLY _caption AS STRING
         PRIVATE INITONLY _result AS DialogResult

--- a/src/Runtime/XSharp.VFP.UI/VfpUIProvider.prg
+++ b/src/Runtime/XSharp.VFP.UI/VfpUIProvider.prg
@@ -23,19 +23,33 @@ BEGIN NAMESPACE XSharp.VFP.UI
     PUBLIC CLASS VfpUIProvider IMPLEMENTS IVfpUIProvider
         #region (Sysmetric, MessageBox, etc)
         PUBLIC METHOD ShowMessageBox(cMessage AS STRING, nDialogBoxType AS LONG, cTitleBarText AS STRING, nTimeOut AS LONG) AS LONG
-            LOCAL nButton AS MessageBoxButtons
-            LOCAL nIcon AS MessageBoxIcon
-            LOCAL nDefault AS MessageBoxDefaultButton
+            LOCAL nResult AS LONG
+            LOCAL dwTimeOut := IIF(nTimeOut > 0, (DWORD)nTimeOut, 0xFFFFFFFF) AS DWORD
 
-            nButton := (MessageBoxButtons) _AND(nDialogBoxType, 0x0F)
-            nIcon := (MessageBoxIcon) _AND(nDialogBoxType, 0xF0)
-            nDefault := (MessageBoxDefaultButton) _AND(nDialogBoxType, 0xF00)
+            VAR sw := System.Diagnostics.Stopwatch.StartNew()
+            nResult := VfpWin32UI.MessageBoxTimeout( ;
+                IntPtr.Zero, ;
+                cMessage, ;
+                cTitleBarText, ;
+                (DWORD)nDialogBoxType, ;
+                0, ;
+                dwTimeout)
 
-            IF nTimeOut >= 1
-                RETURN (LONG) XSharp.VFP.UI.AutoCloseMessageBox.Show(cMessage, cTitleBarText, (INT)nTimeOut, nButton, nIcon, nDefault)
+            sw:Stop()
+
+            // In native API 32000 (0x7D00) means TIMEOUT
+            IF nResult == 32000
+                RETURN -1
             ENDIF
 
-            RETURN (LONG) MessageBox.Show(cMessage, cTitleBarText, nButton, nIcon, nDefault)
+            IF nTimeOut > 0 .AND. sw:ElapsedMilliseconds >= (nTimeOut - 50)
+                VAR nDefaultButtonID := (nDialogBoxType & 0xF00) >> 8
+                IF nResult <= 1 .OR. nResult == (LONG)nDefaultButtonID
+                    RETURN -1
+                ENDIF
+            ENDIF
+
+            RETURN nResult
         END METHOD
 
         PUBLIC METHOD SysMetric(nScreenElement AS LONG) AS LONG

--- a/src/Runtime/XSharp.VFP.UI/Win32UI.prg
+++ b/src/Runtime/XSharp.VFP.UI/Win32UI.prg
@@ -13,6 +13,15 @@ BEGIN NAMESPACE XSharp.VFP.UI
         PUBLIC CONST DESKTOP_HORZRES := 117 AS INT
         PUBLIC CONST DESKTOP_VERTRES := 118 AS INT
 
+        [DllImport("user32.dll", CharSet := CharSet.Unicode, EntryPoint := "MessageBoxTimeoutW")] ;
+        INTERNAL STATIC EXTERN METHOD MessageBoxTimeout( ;
+            hWnd AS IntPtr, ;
+            lpText AS STRING, ;
+            lpCaption AS STRING, ;
+            uType AS DWORD, ;
+            wLanguageId AS WORD, ;
+            dwMilliseconds AS DWORD) AS LONG
+
         [DllImport("gdi32.dll", CharSet := CharSet.Auto, SetLastError := TRUE, ExactSpelling := TRUE)];
         STATIC EXTERN METHOD GetDeviceCaps(hDC AS IntPtr, nIndex AS INT) AS INT
 

--- a/src/Runtime/XSharp.VFP/UIFunctions.prg
+++ b/src/Runtime/XSharp.VFP/UIFunctions.prg
@@ -9,20 +9,40 @@ USING XSharp.VFP
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/messagebox/*" />
 [FoxProFunction("MESSAGEBOX", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION MessageBox( eMessageText AS USUAL, nDialogBoxType := 0 AS LONG, cTitleBarText := "" AS STRING,nTimeOut := 0 AS LONG) AS LONG
+FUNCTION MessageBox( eMessageText AS USUAL, nDialogBoxType := NIL AS USUAL, cTitleBarText := NIL AS USUAL, nTimeOut := NIL AS USUAL) AS LONG
     LOCAL cMessage AS STRING
+    LOCAL nRealType := 0 AS LONG
+    LOCAL cRealTitle := "" AS STRING
+    LOCAL nRealTimeout := 0 AS LONG
+    LOCAL nNumericFound := 0 AS INT
+    LOCAL lTitleSet := FALSE AS LOGIC
 
-    IF !IsString(eMessageText)
-        cMessage := AsString(eMessageText)
-    ELSE
-        cMessage := eMessageText
+    cMessage := IIF(IsString(eMessageText), (STRING)eMessageText, AsString(eMessageText))
+
+    LOCAL aParams := { nDialogBoxType, cTitleBarText, nTimeOut } AS ARRAY
+
+    FOREACH VAR uParam IN aParams
+        IF !IsNil(uParam)
+            IF IsString(uParam) .AND. !lTitleSet
+                cRealTitle := (STRING)uParam
+                lTitleSet := TRUE
+            ELSEIF IsNumeric(uParam)
+                nNumericFound++
+                IF nNumericFound == 1
+                    nRealType := (LONG)uParam
+                ELSEIF nNumericFound == 2
+                    nRealTimeout := (LONG)uParam
+                ENDIF
+            ENDIF
+        ENDIF
+    NEXT
+
+    IF String.IsNullOrEmpty(cRealTitle)
+        cRealTitle := System.IO.Path.GetFileNameWithoutExtension(System.Reflection.Assembly.GetEntryAssembly()?:Location)
+        IF String.IsNullOrEmpty(cRealTitle) ; cRealTitle := "Microsoft Visual FoxPro" ; ENDIF
     ENDIF
 
-    IF String.IsNullOrEmpty(cTitleBarText)
-        cTitleBarText := System.IO.Path.GetFileNameWithoutExtension(System.Reflection.Assembly.GetEntryAssembly():Location)
-    ENDIF
-
-    RETURN VfpUIService.Provider:ShowMessageBox(cMessage, nDialogBoxType, cTitleBarText, nTimeOut)
+    RETURN VfpUIService.Provider:ShowMessageBox(cMessage, nRealType, cRealTitle, nRealTimeout)
 END FUNCTION
 
 /// <include file="VFPDocs.xml" path="Runtimefunctions/sysmetric/*" />


### PR DESCRIPTION
This PR addresses the issue where the `nTimeOut` parameter in `MESSAGEBOX()` failed to close the dialog reliably (failing 9 out of 10 times).

### Changes made
- **Native Win32 API**: Replaced the `FindWindow` approach with the native `MessageBoxTimeoutW` for atomic and reliable timeouts.
- **Smart Parameters**: Updated the `MessageBox` signature to accept `USUAL` types. This fully supports VFP's dynamic parameter ordering (ej: allowing `MESSAGEBOX("Msg", "Title", 64)` or `MESSAGEBOX("Msg", 64, "Title")`).
- **Timeout Fallback**: Added a `Stopwatch` safety check in `VfpUIProvider.prg`. If modern Windows versions return a default button ID instead of `32000` upon timeout, the Stopwatch ensures `-1` is strictly returned to match VFP specs.

### Testing
- All tests was made on XIDE in a separate environment.
- Verified timeout functionality returns `-1` consistently.