### PR TITLE
Implement SET DEVICE TO FILE redirection in VFP

### DIFF
--- a/src/Common/FoxProSet.xh
+++ b/src/Common/FoxProSet.xh
@@ -36,6 +36,7 @@
    SetTextMergeDelimiters(<cLeft>, iif ( <.cRight.>,<!cRight!>,<cLeft>))
 
 #command SET DEVICE TO <x:SCREEN,PRINTER,&>  =>  Set( Set.Device, <(x)> )
+#command SET DEVICE TO FILE <(file)>         =>  Set( Set.Device, "FILE:" + <(file)> )
 
 ///////////////////////////////////////////////////////////////////////////////
 // SET commands for Terminal IO

--- a/src/Runtime/XSharp.RT/Functions/Set.prg
+++ b/src/Runtime/XSharp.RT/Functions/Set.prg
@@ -145,6 +145,22 @@ FUNCTION Set(nDefine, newValue) AS USUAL CLIPPER
             IF IsNumeric(newValue) .AND. newValue == 1
                 RETURN ""
             ENDIF
+        CASE Set.Device
+            IF IsString(newValue)
+                LOCAL cNewDev := ((STRING)newValue):ToUpperInvariant() AS STRING
+                IF cNewDev:StartsWith("FILE:")
+                    VAR cFileName := ((STRING)newValue):Substring(5)
+                    IF ConsoleHelpers.DevFileHandle != IntPtr.Zero
+                        ConsoleHelpers.FileClose(REF ConsoleHelpers.DevFileHandle)
+                    ENDIF
+                    ConsoleHelpers.DevFileHandle := ConsoleHelpers.FileOpen(cFileName, FALSE)
+                    newValue := "FILE"
+                ELSEIF cNewDev == "SCREEN" .OR. cNewDev == "PRINTER"
+                    IF ConsoleHelpers.DevFileHandle != IntPtr.Zero
+                        ConsoleHelpers.FileClose(REF ConsoleHelpers.DevFileHandle)
+                    ENDIF
+                ENDIF
+            ENDIF
         END SWITCH
     ENDIF
 

--- a/src/Runtime/XSharp.RT/Functions/Set.prg
+++ b/src/Runtime/XSharp.RT/Functions/Set.prg
@@ -147,15 +147,20 @@ FUNCTION Set(nDefine, newValue) AS USUAL CLIPPER
             ENDIF
         CASE Set.Device
             IF IsString(newValue)
-                LOCAL cNewDev := ((STRING)newValue):ToUpperInvariant() AS STRING
+                VAR cNewDev := ((STRING)newValue):ToUpperInvariant()
                 IF cNewDev:StartsWith("FILE:")
-                    VAR cFileName := ((STRING)newValue):Substring(5)
+                    VAR cFileName := ((STRING)newValue):Substring(5):Trim()
+                    IF String.IsNullOrWhiteSpace(cFileName)
+                        THROW ArgumentException{"SET DEVICE TO FILE requires a non-empty filename.", nameof(newValue)}
+                    ENDIF
+
                     IF ConsoleHelpers.DevFileHandle != IntPtr.Zero
                         ConsoleHelpers.FileClose(REF ConsoleHelpers.DevFileHandle)
                     ENDIF
+
                     ConsoleHelpers.DevFileHandle := ConsoleHelpers.FileOpen(cFileName, FALSE)
                     newValue := "FILE"
-                ELSEIF cNewDev == "SCREEN" .OR. cNewDev == "PRINTER"
+                ELSE
                     IF ConsoleHelpers.DevFileHandle != IntPtr.Zero
                         ConsoleHelpers.FileClose(REF ConsoleHelpers.DevFileHandle)
                     ENDIF

--- a/src/Runtime/XSharp.RT/Functions/Terminal.prg
+++ b/src/Runtime/XSharp.RT/Functions/Terminal.prg
@@ -83,6 +83,20 @@ INTERNAL FUNCTION TextWriteLine() AS VOID
 
 #endregion
 
+#region SET DEVICE
+INTERNAL FUNCTION DevWrite(cText AS STRING) AS VOID
+    IF XSharp.RuntimeState.GetValue<STRING>(Set.Device) == "FILE" .AND. ConsoleHelpers.DevFileHandle != IntPtr.Zero
+        ConsoleHelpers.Write(ConsoleHelpers.DevFileHandle, cText)
+    ENDIF
+    RETURN
+
+INTERNAL FUNCTION DevWriteLine() AS VOID
+    IF XSharp.RuntimeState.GetValue<STRING>(Set.Device) == "FILE" .AND. ConsoleHelpers.DevFileHandle != IntPtr.Zero
+        ConsoleHelpers.WriteLine(ConsoleHelpers.DevFileHandle)
+    ENDIF
+    RETURN
+#endregion
+
 #region SET CONSOLE
 
 INTERNAL FUNCTION ConsoleWriteLine() AS VOID
@@ -105,12 +119,15 @@ INTERNAL FUNCTION QWriteLine() AS VOID
     ConsoleWriteLine()
     AltWriteLine()
     TextWriteLine()
+    DevWriteLine()
+    RETURN
 
 INTERNAL FUNCTION QWrite(cText as STRING) AS VOID
     IF cText != NULL
         ConsoleWrite(cText)
         AltWrite(cText)
         TextWrite(cText)
+        DevWrite(cText)
     ENDIF
     RETURN
 
@@ -352,6 +369,7 @@ INTERNAL STATIC CLASS ConsoleHelpers
     INTERNAL STATIC TextFileHandle := IntPtr.Zero as IntPtr
     INTERNAL STATIC TextOutPut       AS LOGIC
     INTERNAL STATIC TextFile         AS STRING
+    INTERNAL STATIC DevFileHandle := IntPtr.Zero AS IntPtr
 
 
     //INTERNAL STATIC PrintFileHandle := IntPtr.Zero as IntPtr

--- a/src/Runtime/XSharp.RT/Functions/Terminal.prg
+++ b/src/Runtime/XSharp.RT/Functions/Terminal.prg
@@ -369,6 +369,7 @@ INTERNAL STATIC CLASS ConsoleHelpers
     INTERNAL STATIC TextFileHandle := IntPtr.Zero as IntPtr
     INTERNAL STATIC TextOutPut       AS LOGIC
     INTERNAL STATIC TextFile         AS STRING
+    [ThreadStatic];
     INTERNAL STATIC DevFileHandle := IntPtr.Zero AS IntPtr
 
 

--- a/src/Runtime/XSharp.VFP.Tests/OtherTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/OtherTests.prg
@@ -7,6 +7,7 @@ USING System
 USING System.Collections.Generic
 USING System.Linq
 USING System.Text
+USING System.IO
 USING XUnit
 
 
@@ -116,6 +117,24 @@ BEGIN NAMESPACE XSharp.VFP.Tests
             Assert.True(nHeight > 0, "ScreenHeight should be greater than 0")
         END METHOD
 
+        [Fact];
+        METHOD SetDeviceToFileTest() AS VOID
+            VAR cFile := Path.Combine(Path.GetTempPath(), Guid.NewGuid():ToString() + ".txt")
+            VAR cTestContent := "May the Force be with you, X#"
+            TRY
+                SET DEVICE TO FILE (cFile)
+                ? cTestContent
+            FINALLY
+                SET DEVICE TO SCREEN
+            END TRY
+
+            Assert.True(File(cFile))
+
+            VAR cContent := File.ReadAllText(cFile)
+            Assert.True(cTestContent $ cContent)
+
+            File.Delete(cFile)
+        END METHOD
 	END CLASS
 
 END NAMESPACE

--- a/src/Runtime/XSharp.VFP.Tests/OtherTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/OtherTests.prg
@@ -119,21 +119,25 @@ BEGIN NAMESPACE XSharp.VFP.Tests
 
         [Fact];
         METHOD SetDeviceToFileTest() AS VOID
-            VAR cFile := Path.Combine(Path.GetTempPath(), Guid.NewGuid():ToString() + ".txt")
+            VAR cFile := Path.Combine(Environment.CurrentDirectory, Guid.NewGuid():ToString() + ".txt")
             VAR cTestContent := "May the Force be with you, X#"
             TRY
-                SET DEVICE TO FILE (cFile)
-                ? cTestContent
+                TRY
+                    SET DEVICE TO FILE (cFile)
+                    ? cTestContent
+                FINALLY
+                    SET DEVICE TO SCREEN
+                END TRY
+
+                Assert.True(File(cFile))
+
+                VAR cContent := File.ReadAllText(cFile)
+                Assert.True(cTestContent $ cContent)
             FINALLY
-                SET DEVICE TO SCREEN
+                IF File.Exists(cFile)
+                    File.Delete(cFile)
+                ENDIF
             END TRY
-
-            Assert.True(File(cFile))
-
-            VAR cContent := File.ReadAllText(cFile)
-            Assert.True(cTestContent $ cContent)
-
-            File.Delete(cFile)
         END METHOD
 	END CLASS
 


### PR DESCRIPTION
Added support for `SET DEVICE TO FILE <filename>` command.

## Changes Included:

- **`FoxProSet.xh`:** Updated `#command` definition for `SET DEVICE` to route `FILE <filename>` through the native `Set()` state machine `Set(Set.Device, "FILE:" + <(file)>))`.
- **`Set.prg`**: Intercepted the `Set.Device` state change. It now correctly parses the filename, opens the `DevFileHandle`, and safely closes/flushes the file when reverting the device back to `SCREEN` or `PRINTER`.
- **`Terminal`**: Added `DevFileHandle` to `ConsoleHelpres`. Injected `DevWrite()` and `DevWriteLine()` hooks into `QWrite()` and `QWriteLine()` to mirror the console into the file stream.
