### PR TITLE
vfp: refactored acopy

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/WrappedStubsTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/WrappedStubsTests.prg
@@ -82,6 +82,21 @@ BEGIN NAMESPACE XSharp.VFP.Tests
         END METHOD
         #pragma options("undeclared", default)
 
+        #pragma options ("undeclared", on)
+        [Fact];
+        METHOD ACopyTest() AS VOID
+            DIMENSION aTest[3]
+            aTest[1] := "Apple"
+            aTest[2] := "Banana"
+            aTest[3] := "Pineapple"
+
+            VAR nElements := (INT)ACopy(aTest, aCopied)
+
+            Assert.True(nElements > 0)
+            Assert.Equal(3, (INT)ALEN(aCopied))
+        END METHOD
+        #pragma options ("undeclared", default)
+
         [Fact, Trait("Category", "RuntimeCore")];
         METHOD VersionTest() AS VOID
             LOCAL uRet AS USUAL

--- a/src/Runtime/XSharp.VFP/LanguageCoreWrappers.prg
+++ b/src/Runtime/XSharp.VFP/LanguageCoreWrappers.prg
@@ -3,6 +3,7 @@
 // Licensed under the Apache License, Version 2.0.
 // See License.txt in the project root for license information.
 //
+USING XSharp.Internal
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/left/*" />
 [FoxProFunction("LEFT", FoxFunctionCategory.StringAndCharacter, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.High)];
@@ -326,9 +327,83 @@ FUNCTION Time(nExpression := 0 AS INT) AS STRING
     RETURN XSharp.Core.Functions.Time()
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/acopy/*" />
+[FoxArrayInputParameter(2)];
 [FoxProFunction("ACOPY", FoxFunctionCategory.Array, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION ACopy(aSource AS USUAL, aTarget AS USUAL, nStart := 1 AS USUAL, nCount := -1 AS USUAL, nTargetPos := 1 AS USUAL) AS ARRAY
-    RETURN XSharp.RT.Functions.ACopy(aSource, aTarget, nStart, nCount, nTargetPos)
+FUNCTION ACopy(aSource AS USUAL, aTarget AS USUAL, nStart := 1 AS USUAL, nCount := -1 AS USUAL, nTargetPos := 1 AS USUAL) AS DWORD
+    LOCAL nSourceLen AS LONG
+    LOCAL nStartPos AS LONG
+    LOCAL nElements AS LONG
+    LOCAL nDestPos AS LONG
+    LOCAL nReqSize AS LONG
+    LOCAL nTargetLen AS LONG
+
+    IF !IsArray(aSource)
+        THROW Error.ArgumentError(__FUNCTION__, NAMEOF(aSource), 1, <OBJECT>{ aSource} )
+    ENDIF
+
+    IF !IsArray(aTarget)
+        aTarget := __FoxArray{}
+    ENDIF
+
+    nSourceLen := (LONG) XSharp.RT.Functions.ALen(aSource)
+    IF nSourceLen == 0
+        RETURN 0
+    ENDIF
+
+    nStartPos := 1
+    IF !IsNil(nStart) .AND. IsNumeric(nStart)
+        nStartPos := (LONG) nStart
+    ENDIF
+
+    IF nStartPos < 1
+        nStartPos := 1
+    ENDIF
+
+    IF !IsNil(nCount) .AND. IsNumeric(nCount) .AND. (LONG)nCount >= 0
+        nElements := (LONG) nCount
+    ELSE
+        nElements := nSourceLen - nStartPos + 1
+    ENDIF
+
+    IF nStartPos + nElements - 1 > nSourceLen
+        nElements := nSourceLen - nStartPos + 1
+    ENDIF
+
+    IF nElements <= 0
+        RETURN 0
+    ENDIF
+
+    nDestPos := 1
+    IF !IsNil(nTargetPos) .AND. IsNumeric(nTargetPos)
+        nDestPos := (LONG) nTargetPos
+    ENDIF
+
+    IF nDestPos < 1
+        nDestPos := 1
+    ENDIF
+
+    nTargetLen := (LONG) XSharp.RT.Functions.ALen(aTarget)
+
+    IF nTargetLen == 0 .AND. aSource IS __FoxArray VAR arrSource .AND. aTarget IS __FoxArray VAR arrTarget
+        IF arrSource:MultiDimensional
+            arrTarget:ReDim((DWORD)arrSource:Rows, (DWORD)arrSource:Columns)
+        ENDIF
+    ENDIF
+
+    nTargetLen := (LONG) XSharp.RT.Functions.ALen(aTarget)
+    nReqSize := nDestPos - 1 + nElements
+
+    IF nTargetLen < nReqSize
+        IF aTarget IS __FoxArray VAR arrTarget2
+            arrTarget2:Resize(nReqSize)
+        ELSEIF aTarget IS ARRAY VAR arrTarget2
+            XSharp.RT.Functions.ASize(arrTarget2, (DWORD)nReqSize)
+        ENDIF
+    ENDIF
+
+    XSharp.RT.Functions.ACopy(aSource, aTarget, (DWORD)nStartPos, (DWORD)nElements, (DWORD)nDestPos)
+
+    RETURN (DWORD) nElements
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/ascan/*" />
 [FoxProFunction("ASCAN", FoxFunctionCategory.Array, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.High)];


### PR DESCRIPTION
*Refactored `ACOPY()`
- Added `[FoxArrayInputParameter(2)]` to support dynamic creation of the target array by the compiler.
- Changed the return type from `ARRAY` to `DWORD` to return the number of elements copied.
- Implemented logic to automatically clone the source array's dimensions (1D, 2D) if the target array is empty/newly created.
- The destination array now auto-expands if its current size is smaller than the required size to fit the copied elements.