### PR TITLE
Implementation of LINENO() function

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
@@ -322,6 +322,15 @@ BEGIN NAMESPACE XSharp.VFP.Tests
             Set(Set.MemoWidth, nOld)
         END METHOD
 
+        [Fact];
+        METHOD TestLineNo() AS VOID
+            VAR nLine := LINENO()
+            Assert.True(nLine > 0)
+
+            nLine := LINENO(1)
+            Assert.True(nLine > 0)
+        END METHOD
+
 	END CLASS
 
 END NAMESPACE

--- a/src/Runtime/XSharp.VFP/DebugFunctions.prg
+++ b/src/Runtime/XSharp.VFP/DebugFunctions.prg
@@ -46,3 +46,18 @@ FUNCTION Program( nLevel, lShowSignature) AS USUAL CLIPPER
         endif
     endif
     return ""
+
+/// <include file="VFPDocs.xml" path="Runtimefunctions/lineno/*" />
+[FoxProFunction("LINENO", FoxFunctionCategory.EnvironmentAndSystem, FoxEngine.LanguageCore, FoxFunctionStatus.Stub, FoxCriticality.Low)];
+FUNCTION LineNo(nPos := 0 AS USUAL) AS LONG
+    VAR nLevel := 1
+    LOCAL oFrame := NULL AS StackFrame
+    VAR oTrace := StackTrace{TRUE}
+
+    IF oTrace:FrameCount > nLevel
+        oFrame := oTrace:GetFrame(nLevel)
+        RETURN oFrame:GetFileLineNumber()
+    ENDIF
+
+    RETURN 0
+

--- a/src/Runtime/XSharp.VFP/ToDo-KLM.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-KLM.prg
@@ -13,14 +13,6 @@ FUNCTION KeyMatch(eIndexKey , nIndexNumber , uArea)  AS LOGIC
     THROW NotImplementedException{}
     // RETURN FALSE
 
-
-/// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/lineno/*" />
-[FoxProFunction("LINENO", FoxFunctionCategory.EnvironmentAndSystem, FoxEngine.LanguageCore, FoxFunctionStatus.Stub, FoxCriticality.Low)];
-FUNCTION LineNo(nPos ) AS LONG
-    THROW NotImplementedException{}
-    // RETURN 0
-
 /// <summary>-- todo --</summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/loadpicture/*" />
 [FoxProFunction("LOADPICTURE", FoxFunctionCategory.General, FoxEngine.RuntimeCore, FoxFunctionStatus.Stub, FoxCriticality.Low)];


### PR DESCRIPTION
This PR is part of the Peter Stephan's long feedback list. Added `LINENO()` function.

### Technical Implementation:

- The function utilizes `System.Diagnostics.StackTrace` and `StackFrame` with source information enabled to retrieve line numbers.

### Important Notes for Users:

1. **PDB Dependency:** Line any .NET diagnostic tool, `LINENO()` requires the program's debug symbols (.pdb files) to be present in the execution folder. If symbols are missing, the function will return 0.
2. **Behavioral Differences:** Users should be aware that the returned line numbers may not exactly match those native VFP. This is due to fundamental differences between the VFP interpreter and the .NET/Roslyn compilation process. The function returns the absolute line number of the source file as reported by the CLR.
