### PR TITLE
VFP: Implementation of LOADPICTURE()

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/OtherTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/OtherTests.prg
@@ -25,7 +25,7 @@ BEGIN NAMESPACE XSharp.VFP.Tests
 		METHOD IOTests() AS VOID
 			LOCAL cOldDefault AS STRING
 			cOldDefault := SetDefault()
-			
+
             // In the VO Dialect this is allowed with a non existing path
             XSharp.RuntimeState.Dialect := XSharpDialect.VO
             SetDefault(WorkDir())
@@ -143,6 +143,51 @@ BEGIN NAMESPACE XSharp.VFP.Tests
                     File.Delete(cFile)
                 ENDIF
             END TRY
+        END METHOD
+
+        [Fact];
+        METHOD TestLoadPicture() AS VOID
+            LOCAL oPic AS OBJECT
+
+            // 1. No arguments: should return NULL
+            oPic := LOADPICTURE()
+            Assert.True(oPic == NULL, "LOADPICTURE() without arguments should return NULL")
+
+            oPic := LOADPICTURE("")
+            Assert.True(oPic == NULL, "LOADPICTURE('') should return NULL")
+
+            // 2. Load real file
+            VAR cTempFile := Path.Combine(Path.GetTempPath(), "test.bmp")
+
+            // Create the BMP by hand to avoid polluting the Test project
+            // with specific windows-based asm like System.Drawing
+            VAR aBmpBytes := <BYTE>{;
+                0x42, 0x4D, 0x3A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, ;
+                0x28, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, ;
+                0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ;
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ;
+                0x00, 0x00, 0x00, 0x00 }
+
+            File.WriteAllBytes(cTempFile, aBmpBytes)
+
+            TRY
+                oPic := LOADPICTURE(cTempFile)
+
+                IF VfpUIService.Provider IS HeadlessUIProvider
+                    Assert.True(oPic == NULL, "LOADPICTURE should return NULL in Headless mode.")
+                ELSE
+                   Assert.NotNull(oPic)
+                   VAR cTypeName := oPic:GetType():FullName
+                   Assert.True(cTypeName:Contains("Drawing") .OR. cTypeName:Contains("Image") .OR. cTypeName:Contains("Bitmap"))
+                ENDIF
+            FINALLY
+                IF File.Exists(cTempFile)
+                    File.Delete(cTempFile)
+                ENDIF
+            END TRY
+
+
+
         END METHOD
 	END CLASS
 

--- a/src/Runtime/XSharp.VFP.UI/VfpUIProvider.prg
+++ b/src/Runtime/XSharp.VFP.UI/VfpUIProvider.prg
@@ -274,6 +274,20 @@ BEGIN NAMESPACE XSharp.VFP.UI
 
             RETURN {}
         END METHOD
+
+        METHOD LoadPicture(cFileName AS STRING) AS OBJECT
+            LOCAL oImage AS OBJECT
+
+            TRY
+                oImage := System.Drawing.Image.FromFile(cFileName)
+            CATCH e AS Exception
+                VAR err := Error.WrapRawException(e)
+                err:FuncSym := "LOADPICTURE"
+                THROW err
+            END TRY
+
+            RETURN oImage
+        END METHOD
         #endregion
 
         #region GET* Dialogs

--- a/src/Runtime/XSharp.VFP/ToDo-KLM.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-KLM.prg
@@ -13,13 +13,6 @@ FUNCTION KeyMatch(eIndexKey , nIndexNumber , uArea)  AS LOGIC
     THROW NotImplementedException{}
     // RETURN FALSE
 
-/// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/loadpicture/*" />
-[FoxProFunction("LOADPICTURE", FoxFunctionCategory.General, FoxEngine.RuntimeCore, FoxFunctionStatus.Stub, FoxCriticality.Low)];
-FUNCTION LoadPicture( cFileName ) AS OBJECT
-    THROW NotImplementedException{}
-    // RETURN NULL_OBJECT
-
 
 /// <summary>-- todo --</summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/locfile/*" />

--- a/src/Runtime/XSharp.VFP/UI/UIAndWindows.prg
+++ b/src/Runtime/XSharp.VFP/UI/UIAndWindows.prg
@@ -43,3 +43,23 @@ FUNCTION ChrSaw(nSeconds := 0 AS REAL8) AS LOGIC
 [FoxProFunction("RGB", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Full, FoxCriticality.Medium)];
 FUNCTION RGB(nRedValue AS BYTE, nGreenValue AS BYTE, nBlueValue AS BYTE) AS DWORD
     RETURN XSharp.Core.Functions.RGB(nRedValue, nGreenValue, nBlueValue)
+
+/// <include file="VFPDocs.xml" path="Runtimefunctions/loadpicture/*" />
+[FoxProFunction("LOADPICTURE", FoxFunctionCategory.General, FoxEngine.RuntimeCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
+FUNCTION LoadPicture(cFileName := "" AS STRING) AS OBJECT
+    IF IsNil(cFileName) .OR. Empty(cFileName)
+        RETURN NULL_OBJECT
+    ENDIF
+
+    LOCAL cFile AS STRING
+    cFile := (STRING) cFileName
+
+    // use XSharp.Core.Functions.File to respect the SET PATH
+    IF XSharp.Core.Functions.File(cFileName)
+        cFile := XSharp.Core.Functions.FPathName()
+    ELSE
+        VAR err := Error.ArgumentError(__FUNCTION__, NAMEOF(cFileName), 1, "File does not exist: " + cFileName)
+        THROW err
+    ENDIF
+
+    RETURN VfpUIService.Provider:LoadPicture(cFile)

--- a/src/Runtime/XSharp.VFP/UI/VfpUIService.prg
+++ b/src/Runtime/XSharp.VFP/UI/VfpUIService.prg
@@ -21,6 +21,7 @@ BEGIN NAMESPACE XSharp.VFP
         METHOD GetDir(cDirectory AS STRING, cText AS STRING, cCaption AS STRING, nFlags AS LONG, lRootOnly AS LOGIC) AS STRING
         METHOD GetFile(cFileExtensions AS STRING, cText AS STRING, cOpenButtonCaption AS STRING, nButtonType AS LONG, cTitleBarCaption AS STRING) AS STRING
         METHOD GetPict(cFileExtensions AS STRING, cFileNameCaption AS STRING, cOpenButtonCaption AS STRING) AS STRING
+        METHOD LoadPicture(cFileName AS STRING) AS OBJECT
     END INTERFACE
 
     PUBLIC STATIC CLASS VfpUIService
@@ -147,6 +148,11 @@ BEGIN NAMESPACE XSharp.VFP
 
         METHOD GetPict(cFileExtensions AS STRING, cFileNameCaption AS STRING, cOpenButtonCaption AS STRING) AS STRING
             RETURN ""
+        END METHOD
+
+        METHOD LoadPicture(cFileName AS STRING) AS OBJECT
+            Console.WriteLine("LOADPICTURE: Attempted to load: " + cFileName)
+            RETURN NULL_OBJECT
         END METHOD
 
     END CLASS


### PR DESCRIPTION
Implementation of `LOADPICTURE()` function.

### Technical Implementation
- **Core Runtime:** Moved `LOADPICTURE` from `Todo-KLM.prg` to `UIAndWindows.prg`. The function now handles parameter validation and file path resolucion (respecting `SET PATH` via `File()` and `FPathName()`), then delegates the actual image loading to the `VfpUIService.Provider`.
- **UI Provider Interface:** Added the `LoadPicture(cFileName)` method to `IVfpUIProvider`.
- **Headledd Support:** Implemented a no-op version in `HeadlessUIProvider` to ensure the runtime remains stable in console or service environments with GDI+ deps.
- **VFP UI Implementation:** Added the concrete implementation in `XSharp.VFP.UI.VfpUIProvider`, utilizing `System.Drawing.Image.FromFile()` to load the resource.

### Behavioral Changes (VFP vs .NET)
- **Return Type:** In native VFP, this function returns a COM `IPictureDisp` object. In X#, it returns a `.NET System.Drawing.Image` (or `Bitmap`) object. This change is neccesary for seamless integration with WinForms and modern .NET UI controls.
- **Dependencies:** This implementation ensures that `XSharp.VFP.dll` does not have a direct dependency on `System.Drawing.Common`, preserving cross-platform compatibility for the core library.