### PR TITLE
[VsIntegration] Correction to run RefreshIncludeFile in the UI Thread

### DIFF
--- a/src/VisualStudio/ProjectPackage/Nodes/XSharpProjectNode.cs
+++ b/src/VisualStudio/ProjectPackage/Nodes/XSharpProjectNode.cs
@@ -1355,7 +1355,7 @@ namespace XSharp.Project
         public XSharpPackageReferenceContainerNode GetPackageReferenceContainerNode()
         {
             var node = FindChild(XSharpPackageReferenceContainerNode.PackageReferencesNodeVirtualName) as XSharpPackageReferenceContainerNode;
-            if (node == null )
+            if (node == null)
             {
                 var referenceContainerNode = GetReferenceContainer() as HierarchyNode;
                 node = new XSharpPackageReferenceContainerNode(this);
@@ -1574,7 +1574,7 @@ namespace XSharp.Project
                 }
                 _taskListManager.Refresh();
             }
-            RefreshIncludeFiles();
+            ThreadUtilities.runSafe(RefreshIncludeFiles);
 
         }
 
@@ -1637,14 +1637,10 @@ namespace XSharp.Project
             finally
             {
                 this.EventTriggeringFlag = oldEvents;
-                ThreadUtilities.runSafe(() =>
+                if (hasChanged)
                 {
-                    if (hasChanged)
-                    {
-                        this.OnItemsAppended(includeNode);
-                    }
-
-                });
+                    this.OnItemsAppended(includeNode);
+                }
             }
         }
         private void OnFileWalkComplete(XFile xfile)
@@ -1837,7 +1833,7 @@ namespace XSharp.Project
                 {
                     switch (item.ItemType.ToLower())
                     {
-                        case "reference" when ! isSdk:
+                        case "reference" when !isSdk:
                             allReferenceAssemblies.AddUnique(item);
                             break;
                         case "referencepath" when isSdk:


### PR DESCRIPTION
Changed RefreshIncludeFiles() to ThreadUtilities.runSafe(RefreshIncludeFiles) — this marshals the entire method to the UI thread.

The walker thread briefly blocks while the UI work completes, which is acceptable — hierarchy node manipulation must be synchronous with the UI thread anyway.