### PR TITLE
implement TXNLEVEL() transaction level function

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
@@ -353,6 +353,11 @@ BEGIN NAMESPACE XSharp.VFP.Tests
         METHOD PColTest() AS VOID
             Assert.Equal(0, PCol())
         END METHOD
+
+        [Fact, Trait("Category", "Database")];
+        METHOD TxnLevelTest() AS VOID
+            Assert.Equal(0, TxnLevel())
+        END METHOD
 	END CLASS
 
 END NAMESPACE

--- a/src/Runtime/XSharp.VFP/Database/DbFunctions.prg
+++ b/src/Runtime/XSharp.VFP/Database/DbFunctions.prg
@@ -12,6 +12,13 @@ USING XSharp.RDD
 USING System.Collections.Generic
 USING XSharp.RDD.Support
 USING XSharp.Internal
+
+/// <summary>Internal transaction nesting level.
+/// Incremented by BEGIN TRANSACTION, decremented
+/// by END TRANSACTION/ROLLBACK
+GLOBAL __FoxTnxLevel := 0 AS LONG
+
+/// </summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/dbgetprop/*" />
 /// <seealso cref="DbSetProp" />
 /// <seealso cref="DbcDatabase" />
@@ -553,6 +560,11 @@ FUNCTION Seek(uExpression, uWorkarea, uOrder) AS LOGIC CLIPPER
     	DbSelectArea( dwCurrentWorkarea )
     END IF
     RETURN lResult
+
+/// <include file="VFPDocs.xml" path="Runtimefunctions/txnlevel/*" />
+[FoxProFunction("TXNLEVEL", FoxFunctionCategory.Database, FoxEngine.SQL, FoxFunctionStatus.Full, FoxCriticality.High)];
+FUNCTION TxnLevel( ) AS LONG
+    RETURN __FoxTnxLevel
 
 FUNCTION DbCopyStructFox(cTargetFile, aFields, lCdx) AS LOGIC CLIPPER
     local acStruct as ARRAY

--- a/src/Runtime/XSharp.VFP/ToDo-TUVWX.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-TUVWX.prg
@@ -19,14 +19,6 @@ FUNCTION TableUpdate( nRows , lForce , uArea , cErrorArray) AS LOGIC
     THROW NotImplementedException{}
     // RETURN FALSE
 
-
-/// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/txnlevel/*" />
-[FoxProFunction("TXNLEVEL", FoxFunctionCategory.Database, FoxEngine.SQL, FoxFunctionStatus.Stub, FoxCriticality.High)];
-FUNCTION TxnLevel( ) AS LONG
-    THROW NotImplementedException{}
-    // RETURN 0
-
 /// <summary>-- todo --</summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/txtwidth/*" />
 [FoxProFunction("TXTWIDTH", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Stub, FoxCriticality.Medium)];


### PR DESCRIPTION
`TXNLEVEL()` returns current transaction nesting level (0-5). Uses `__FoxTxnLevel` GLOBAL as future integration point for `BEGIN TRANSACTION` / `END TRANSACTION` / `ROLLBACK`. Returns 0 until transaction commands are implemented.