### PR TITLE
implement ISMEMOFETCHED() function (partial)

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
@@ -358,6 +358,24 @@ BEGIN NAMESPACE XSharp.VFP.Tests
         METHOD TxnLevelTest() AS VOID
             Assert.Equal(0, TxnLevel())
         END METHOD
+
+        [Fact, Trait("Category", "Database")];
+        METHOD IsMemoFetched_NoTableTest() AS VOID
+            Assert.False(IsMemoFetched("memoField"))
+        END METHOD
+
+        [Fact, Trait("Category", "Database")];
+        METHOD IsMemoFetched_WithCursorTest() AS VOID
+            CREATE CURSOR TestCursor (custId I, notes C(10))
+            INSERT INTO TestCursor VALUES (1, "test memo")
+            GO TOP
+
+            Assert.True(IsMemoFetched("notes"))
+            Assert.True(IsMemoFetched(2))
+            GO BOTTOM
+            SKIP // go to EOF
+            Assert.False(IsMemoFetched("notes"))
+        END METHOD
 	END CLASS
 
 END NAMESPACE

--- a/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
@@ -372,6 +372,10 @@ BEGIN NAMESPACE XSharp.VFP.Tests
 
             Assert.True(IsMemoFetched("notes"))
             Assert.True(IsMemoFetched(2))
+            GO TOP
+            SKIP -1 // set BOF
+            Assert.True(IsNull(IsMemoFetched("notes")))
+
             GO BOTTOM
             SKIP // go to EOF
             Assert.True(IsNull(IsMemoFetched("notes")))

--- a/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/MiscTests.prg
@@ -366,7 +366,7 @@ BEGIN NAMESPACE XSharp.VFP.Tests
 
         [Fact, Trait("Category", "Database")];
         METHOD IsMemoFetched_WithCursorTest() AS VOID
-            CREATE CURSOR TestCursor (custId I, notes C(10))
+            CREATE CURSOR TestCursor (custId I, notes M)
             INSERT INTO TestCursor VALUES (1, "test memo")
             GO TOP
 
@@ -374,7 +374,7 @@ BEGIN NAMESPACE XSharp.VFP.Tests
             Assert.True(IsMemoFetched(2))
             GO BOTTOM
             SKIP // go to EOF
-            Assert.False(IsMemoFetched("notes"))
+            Assert.True(IsNull(IsMemoFetched("notes")))
         END METHOD
 	END CLASS
 

--- a/src/Runtime/XSharp.VFP/Database/DbFunctions.prg
+++ b/src/Runtime/XSharp.VFP/Database/DbFunctions.prg
@@ -566,6 +566,20 @@ FUNCTION Seek(uExpression, uWorkarea, uOrder) AS LOGIC CLIPPER
 FUNCTION TxnLevel( ) AS LONG
     RETURN __FoxTnxLevel
 
+/// <include file="VFPDocs.xml" path="Runtimefunctions/ismemofetched/*" />
+[FoxProFunction("ISMEMOFETCHED", FoxFunctionCategory.SQL, FoxEngine.SQL, FoxFunctionStatus.Partial, FoxCriticality.Medium)];
+FUNCTION IsMemoFetched( uField AS USUAL, uArea := NIL AS USUAL) AS LOGIC
+    IF !XSharp.RT.Functions.Used()
+        RETURN FALSE
+    ENDIF
+    RETURN _DoInArea(uArea, { =>
+        IF Bof() .OR. Eof()
+            RETURN FALSE
+        ENDIF
+        RETURN TRUE
+    }, FALSE, __FUNCTION__, 2)
+
+
 FUNCTION DbCopyStructFox(cTargetFile, aFields, lCdx) AS LOGIC CLIPPER
     local acStruct as ARRAY
     IF IsArray(aFields)

--- a/src/Runtime/XSharp.VFP/Database/DbFunctions.prg
+++ b/src/Runtime/XSharp.VFP/Database/DbFunctions.prg
@@ -572,7 +572,7 @@ FUNCTION IsMemoFetched( uField AS USUAL, uArea := NIL AS USUAL) AS USUAL
     IF !XSharp.RT.Functions.Used()
         RETURN FALSE
     ENDIF
-    IF XSharp.RT.Functions.Eof()
+    IF XSharp.RT.Functions.Bof() .or. XSharp.RT.Functions.Eof()
         RETURN DBNull.Value
     ENDIF
     RETURN TRUE

--- a/src/Runtime/XSharp.VFP/Database/DbFunctions.prg
+++ b/src/Runtime/XSharp.VFP/Database/DbFunctions.prg
@@ -568,17 +568,14 @@ FUNCTION TxnLevel( ) AS LONG
 
 /// <include file="VFPDocs.xml" path="Runtimefunctions/ismemofetched/*" />
 [FoxProFunction("ISMEMOFETCHED", FoxFunctionCategory.SQL, FoxEngine.SQL, FoxFunctionStatus.Partial, FoxCriticality.Medium)];
-FUNCTION IsMemoFetched( uField AS USUAL, uArea := NIL AS USUAL) AS LOGIC
+FUNCTION IsMemoFetched( uField AS USUAL, uArea := NIL AS USUAL) AS USUAL
     IF !XSharp.RT.Functions.Used()
         RETURN FALSE
     ENDIF
-    RETURN _DoInArea(uArea, { =>
-        IF Bof() .OR. Eof()
-            RETURN FALSE
-        ENDIF
-        RETURN TRUE
-    }, FALSE, __FUNCTION__, 2)
-
+    IF XSharp.RT.Functions.Eof()
+        RETURN DBNull.Value
+    ENDIF
+    RETURN TRUE
 
 FUNCTION DbCopyStructFox(cTargetFile, aFields, lCdx) AS LOGIC CLIPPER
     local acStruct as ARRAY

--- a/src/Runtime/XSharp.VFP/ToDo-HI.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-HI.prg
@@ -34,13 +34,6 @@ FUNCTION IsExclusive( uArea, nType) AS LOGIC
     // RETURN FALSE
 
 /// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/ismemofetched/*" />
-[FoxProFunction("ISMEMOFETCHED", FoxFunctionCategory.SQL, FoxEngine.SQL, FoxFunctionStatus.Stub, FoxCriticality.Medium)];
-FUNCTION IsMemoFetched( uField , uArea) AS LOGIC
-    THROW NotImplementedException{}
-    // RETURN FALSE
-
-/// <summary>-- todo --</summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/istransactable/*" />
 [FoxProFunction("ISTRANSACTABLE", FoxFunctionCategory.Database, FoxEngine.WorkArea, FoxFunctionStatus.Stub, FoxCriticality.High)];
 FUNCTION IsTransactable( uArea ) AS LOGIC


### PR DESCRIPTION
Checks memo field fetch status. For local data (DBF), memo is always fetched. 
Marked `Partial`. Full support require remote views or cursor adapters.