### PR TITLE
[VFP] Fix CREATE TABLE with path in table name

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/CommandTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/CommandTests.prg
@@ -89,6 +89,34 @@ BEGIN NAMESPACE XSharp.VFP.Tests
             END TRY
         RETURN
 
+        [Fact];
+        METHOD TestCreateTableWithPath() AS VOID
+            VAR cOldDir := Directory.GetCurrentDirectory()
+            VAR cTempPath := Path.Combine(Path.GetTempPath(), "CreateTableTest_" + Guid.NewGuid():ToString("N"))
+            VAR cSubDir := Path.Combine(cTempPath, "SubDir")
+            System.IO.Directory.CreateDirectory(cSubDir)
+
+            TRY
+                SET DEFAULT TO (cTempPath)
+                VAR cFile1 := Path.Combine(cSubDir, "TestTable1.dbf")
+                CREATE TABLE (cFile1) (Id INT, Name C(20))
+                Assert.True(File.Exists(cFile1))
+                Assert.True(Used("TestTable1"))
+
+                VAR cFile2 := Path.Combine(cSubDir, "TestTable2.dbf")
+                CREATE TABLE (cFile2) (Id INT, Value c(10))
+                Assert.True(File.Exists(cFile2))
+                Assert.True(Used("TestTable2"))
+                XSharp.CoreDb.CloseAll()
+            FINALLY
+                System.IO.Directory.SetCurrentDirectory(cOldDir)
+                TRY
+                    System.IO.Directory.Delete(cTempPath, TRUE)
+                CATCH
+                END TRY
+            END TRY
+        END METHOD
+
     END CLASS
 
 END NAMESPACE

--- a/src/Runtime/XSharp.VFP/SQL/EmbeddedSql.prg
+++ b/src/Runtime/XSharp.VFP/SQL/EmbeddedSql.prg
@@ -129,16 +129,20 @@ STATIC CLASS FoxEmbeddedSQL
                 var aField := {col:Name, ((Char)col:FieldType):ToString(), col:Length, col:Decimals, col:Name, col:Flags}
                 AAdd(aStruct, aField)
             next
+
             VAR cTable := oTable:Name
+            VAR cAlias := Path.GetFileNameWithoutExtension(oTable:Name)
             if oTable:IsCursor
-                cTable := System.IO.Path.GetTempFileName()
+                cTable := Path.GetTempFileName()
+                cAlias := oTable:Name
             ENDIF
-            if RuntimeState.Workareas.FindAlias(oTable:Name) != 0
-                DbCloseArea(oTable:Name)
+            if RuntimeState.Workareas.FindAlias(cAlias) != 0
+                DbCloseArea(cAlias)
             endif
-            DbCreate(cTable, aStruct, "DBFVFP", TRUE, oTable:Name)
-            DbCloseArea(oTable:Name)
-            DbUseArea(TRUE, "DBFVFP", cTable, oTable:Name, FALSE, FALSE)
+            DbCreate(cTable, aStruct, "DBFVFP", TRUE, cAlias)
+            DbCloseArea(cAlias)
+            DbUseArea(TRUE, "DBFVFP", cTable, cAlias, FALSE, FALSE)
+
             FOR var nI := 1 to oTable:Columns:Count
                 var oCol := oTable:Columns[nI-1]
                 DbFieldInfo(DBS_CAPTION, nI, oCol:Caption)


### PR DESCRIPTION
- Fix is in `EmbeddedSql.prg`: `CreateTableCursor` derives the alias name from `Path.GetFileNameWithoutExtension()` instead of using the full path.