### PR TITLE
feature: absorb the LABEL command

### DIFF
--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -627,8 +627,8 @@
 #translate CAST ( <expression> AS <type:W,C,Y,D,T,B,F,G,I,L,M,N,Q,V>(<width> ) )        => __FoxCast(<expression>,<(type)>, <width>,-1)
 #translate CAST ( <expression> AS <type:W,C,Y,D,T,B,F,G,I,L,M,N,Q,V>(<width> ,<dec>) )  => __FoxCast(<expression>,<(type)>, <width>,<dec>)
 
+#command LABEL <*any*> => __VfpUnsupported("LABEL")
 
-// unsupported commands
 #command CREATE <cmd:CLASS, CLASSLIB, COLOR, CONNECTION, FORM, LABEL, MENU, PROJECT, QUERY, REPORT, SCREEN, STRUCTURE, TRIGGER>  <*any*> ;
          => #error This command is not supported: <(udc)>
 

--- a/src/Runtime/XSharp.VFP.Tests/CommandTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/CommandTests.prg
@@ -348,6 +348,18 @@ BEGIN NAMESPACE XSharp.VFP.Tests
                 TRY ; System.IO.Directory.Delete(cTempPath, TRUE) ; CATCH ; END TRY
             END TRY
         END METHOD
+
+        [Fact];
+        METHOD LabelCommandAbsorbed() AS VOID
+            // LABEL FORM should compile and run without error (silent no-op)
+            LABEL FORM "nonexistent.lbx"
+            LABEL FORM "nonexistent.lbx" FOR .T.
+            LABEL FORM "nonexistent.lbx" TO FILE "output.txt"
+            LABEL FORM "nonexistent.lbx" TO PRINTER
+            LABEL FORM "nonexistent.lbx" PREVIEW NOWAIT
+            // If we get here without exception, the command is properly absorbed
+            Assert.True(.T.)
+        END METHOD
     END CLASS
 
 END NAMESPACE

--- a/src/Runtime/XSharp.VFP/MiscFunctions.prg
+++ b/src/Runtime/XSharp.VFP/MiscFunctions.prg
@@ -237,3 +237,8 @@ ENDFUNC
 FUNCTION IsPen() AS LOGIC
     RETURN FALSE
 ENDFUNC
+
+/// <exclude/>
+FUNCTION __VfpUnsupported(cCommand AS STRING) AS VOID
+    // Silently absorb all unsupported VFP commands
+    RETURN


### PR DESCRIPTION
Silently absorb the `LABEL` command and derivates the implementation to the new `__VfpUnsupported()` function in `MiscFunctions.prg`.
