### PR TITLE
Fix INDEX ON with ALLTRIM/LTRIM/RTRIM

### DIFF
--- a/src/Runtime/XSharp.Rdd/DbfCdx/Tag/CdxTag.prg
+++ b/src/Runtime/XSharp.Rdd/DbfCdx/Tag/CdxTag.prg
@@ -245,14 +245,32 @@ BEGIN NAMESPACE XSharp.RDD.CDX
                     return FALSE
                 elseif strKey:Length == 0
                     if SELF:RDD Is DBFVFP
-                        foreach var fld in fields
-                            var fldInfo := SELF:_oRdd:_Fields[fld-1]
-                            strKey += String{' ', fldInfo:Length}
-                        next
-                        oKey := strKey
+                        VAR lGotKey := FALSE
+                        TRY
+                            SELF:_oRdd:GoTo(1)
+                            oKey := SELF:_oRdd:EvalBlock(SELF:_KeyCodeBlock)
+                            IF oKey IS STRING VAR strKey2 .AND. strKey2:Length > 0
+                                lGotKey := TRUE
+                            ENDIF
+                        CATCH
+                        END TRY
+                        IF !lGotKey
+                            VAR cPad := ""
+                            FOREACH VAR fld IN fields
+                                VAR fldInfo := SELF:_oRdd:_Fields[fld-1]
+                                cPad += String{' ', fldInfo:Length}
+                            NEXT
+                            IF cPad:Length > 0
+                                oKey := cPad
+                            ELSE
+                                var sMessage := __ErrString(VOErrors.INDEX_EXPRESSION_ZEROLENGTH,SELF:_KeyExpr)
+                                SELF:_oRdd:_dbfError(Subcodes.EDB_EXPRESSION,Gencode.EG_SYNTAX, "DBFCDX.EvaluateExpressions",sMessage ,FALSE)
+                                RETURN FALSE
+                            ENDIF
+                        ENDIF
                     else
-                        var sMessage := __ErrString(VOErrors.INDEX_EXPRESSION_ZEROLENGTH,SELF:_KeyExpr)
-                        SELF:_oRdd:_dbfError(Subcodes.EDB_EXPRESSION,Gencode.EG_SYNTAX, "DBFCDX.EvaluateExpressions",sMessage ,FALSE)
+                        var sMessage := __ErrString(VOErrors.INDEX_EXPRESSION_ZEROLENGTH, SELF:_KeyExpr)
+                        SELF:_oRdd:_dbfError(Subcodes.EDB_EXPRESSION, Gencode.EG_SYNTAX, "DBFCDX.EvaluateExpressions", sMessage, FALSE)
                         return FALSE
                     endif
                 endif

--- a/src/Runtime/XSharp.VFP.Tests/IndexOnTrimTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/IndexOnTrimTests.prg
@@ -1,0 +1,59 @@
+using System
+using System.IO
+using XUnit
+
+begin namespace XSharp.VFP.Tests
+    class IndexOnTrimTests
+        static constructor
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+        end constructor
+
+        [Fact];
+        method TestIndexOnAllTrim() as void
+            var cOldDir := System.IO.Directory.GetCurrentDirectory()
+            var oDir := System.IO.Directory.CreateDirectory(;
+                Path.Combine(Path.GetTempPath(), ;
+                "IdxTrimTest_" + Guid.NewGuid():ToString("N")))
+            var cTempPath := oDir:FullName
+
+            try
+                SET DEFAULT TO (cTempPath)
+                CREATE TABLE TrimTest (Id int, Name c(30), City C(20))
+                INSERT INTO TrimTest VALUES(1, "  Alpha  ", "Berlin")
+                INSERT INTO TrimTest VALUES(2, "Beta", "Munich")
+                INSERT INTO TrimTest VALUES(3, "  Gamma  ", "")
+                INSERT INTO TrimTest VALUES(4, "", "Hamburg")
+
+                INDEX ON ALLTRIM(Name) TAG NameIdx
+                GO TOP
+                Assert.Equal(4, (int)RecNo())
+                SKIP
+                Assert.Equal(1, (int)RecNo())
+
+                INDEX ON LTRIM(Name) TAG LNameIdx
+                GO TOP
+                Assert.True(RecNo() > 0)
+
+                INDEX ON RTRIM(Name) TAG RNameIdx
+                GO TOP
+                Assert.True(RecNo() > 0)
+
+                INDEX ON UPPER(SUBSTR(LTRIM(Name), 1, 5)) TAG SubIdx
+                GO TOP
+                Assert.True(RecNo() > 0)
+
+                INDEX ON ALLTRIM(Name) + ALLTRIM(City) TAG CombIdx
+                GO TOP
+                Assert.True(RecNo() > 0)
+            finally
+                XSharp.CoreDb.CloseAll()
+                SET DEFAULT TO (cOldDir)
+                System.IO.Directory.SetCurrentDirectory(cOldDir)
+                try
+                    System.IO.Directory.Delete(cTempPath)
+                catch
+                end try
+            end try
+        end method
+    end class
+end namespace

--- a/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
+++ b/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
@@ -98,6 +98,7 @@
     <Compile Include="CopyToTests.prg" />
     <Compile Include="FileVersionTests.prg" />
     <Compile Include="FinancialTests.prg" />
+    <Compile Include="IndexOnTrimTests.prg" />
     <Compile Include="SQLStatementTests.prg" />
     <Compile Include="StrConvTests.prg" />
     <Compile Include="TypeTests.prg" />


### PR DESCRIPTION
Fixed issue reported from Peter Stephan.

When creating an index using `INDEX ON` with expressions containing `ALLTRIM()`, `LTRIM()`, `RTRIM()`, a runtime error was thrown.