### PR TITLE
fix: strtran, execscript, set

### DIFF
--- a/src/Runtime/XSharp.VFP/LanguageCoreWrappers.prg
+++ b/src/Runtime/XSharp.VFP/LanguageCoreWrappers.prg
@@ -53,7 +53,15 @@ FUNCTION Occurs(uSearch AS STRING, cTarget AS STRING) AS DWORD
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/strtran/*" />
 [FoxProFunction("STRTRAN", FoxFunctionCategory.StringAndCharacter, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.High)];
 FUNCTION StrTran(uTarget, uSearch, uReplace, uStart, uCount) AS STRING CLIPPER
-    RETURN XSharp.RT.Functions.StrTran(uTarget, uSearch, uReplace, uStart, uCount)
+    switch PCount()
+    case 3
+        RETURN XSharp.RT.Functions.StrTran(uTarget, uSearch, uReplace)
+    case 4
+        RETURN XSharp.RT.Functions.StrTran(uTarget, uSearch, uReplace, uStart)
+    case 5
+        RETURN XSharp.RT.Functions.StrTran(uTarget, uSearch, uReplace, uStart, uCount)
+    end switch
+    RETURN XSharp.RT.Functions.StrTran(uTarget, uSearch, uReplace)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/val/*" />
 [FoxProFunction("VAL", FoxFunctionCategory.MathAndNumeric, FoxEngine.LanguageCore, FoxFunctionStatus.Full, FoxCriticality.High)];

--- a/src/Runtime/XSharp.VFP/MacroWrappers.prg
+++ b/src/Runtime/XSharp.VFP/MacroWrappers.prg
@@ -15,7 +15,17 @@ FUNCTION Evaluate(cString AS STRING) AS USUAL
 /// <include file="VfpDocs.xml" path="Runtimefunctions/execscript/*" />
 [FoxProFunction("EXECSCRIPT", FoxFunctionCategory.General, FoxEngine.Macro, FoxFunctionStatus.Partial, FoxCriticality.High)];
 FUNCTION ExecScript(cExpression, eParameter1, eParameter2, eParameterN) AS USUAL CLIPPER
-    RETURN XSharp.RT.Functions.ExecScript(cExpression, eParameter1, eParameter2, eParameterN)
+    switch PCount()
+    case 1
+        RETURN XSharp.RT.Functions.ExecScript(cExpression)
+    case 2
+        RETURN XSharp.RT.Functions.ExecScript(cExpression, eParameter1)
+    case 3
+        RETURN XSharp.RT.Functions.ExecScript(cExpression, eParameter1, eParameter2)
+    case 4
+        RETURN XSharp.RT.Functions.ExecScript(cExpression, eParameter1, eParameter2, eParameterN)
+    end switch
+    RETURN XSharp.RT.Functions.ExecScript(cExpression)
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/type/*" />
 [NeedsAccessToLocals(FALSE)];

--- a/src/Runtime/XSharp.VFP/RuntimeCoreWrappers.prg
+++ b/src/Runtime/XSharp.VFP/RuntimeCoreWrappers.prg
@@ -322,5 +322,8 @@ FUNCTION OemToAnsi(cOemString AS STRING) AS STRING
 
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/set/*" />
 [FoxProFunction("SET", FoxFunctionCategory.EnvironmentAndSystem, FoxEngine.RuntimeCore, FoxFunctionStatus.Full, FoxCriticality.High)];
-FUNCTION Set(cSETCommand AS USUAL, newValue AS USUAL) AS USUAL
-    RETURN XSharp.RT.Functions.Set(cSETCommand, newValue)
+FUNCTION Set(cSETCommand, newValue) AS USUAL CLIPPER
+    IF PCount() > 1
+        RETURN XSharp.RT.Functions.Set(cSETCommand, newValue)
+    ENDIF
+    RETURN XSharp.RT.Functions.Set(cSETCommand)


### PR DESCRIPTION
`ExecScript()`, `Set()`, `StrTran()`: These functions were passing all declared parameters including NIL for unused ones causing incorrect behavior.
