### PR TITLE
Feature/vfp absorb commands

### DIFF
--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -659,8 +659,8 @@
 
 #command LABEL <*any*> => __VfpUnsupported("LABEL")
 
-#command CREATE <cmd:CLASS, CLASSLIB, COLOR, CONNECTION, FORM, LABEL, MENU, PROJECT, QUERY, REPORT, SCREEN, STRUCTURE, TRIGGER>  <*any*> ;
-         => #error This command is not supported: <(udc)>
+#command CREATE <cmd:CLASS, CLASSLIB, COLOR, FORM, LABEL, MENU, PROJECT, QUERY, REPORT, SCREEN, STRUCTURE, TRIGGER>  <*any*> ;
+         => __VfpUnsupported( <"udc"> )
 
 // supported CREATE commands in FoxProSql.xh
 // CREATE CURSOR
@@ -669,7 +669,7 @@
 // CREATE [SQL] VIEW
 
 #command MODIFY <cmd:COMMAND, CLASS, DATABASE, CONNECTION, FILE, FORM, GENERAL, LABEL, MEMO, MENU, PROCEDURE, PROJECT, QUERY, REPORT, SCREEN, STRUCTURE, WINDOW>  <*any*> ;
-            => #error This command is not supported: <(udc)>
+            => __VfpUnsupported( <"udc"> )
 
 #ifndef NOASSERT
 #command ASSERT <expression> [MESSAGE <cMessageText>]  ;

--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -711,6 +711,21 @@
 #command MENU <*any*> => __VfpUnsupported( <"udc"> )
 #command MENU TO <*any*> => __VfpUnsupported( <"udc"> )
 
+// Generic ON commands
+#command ON <cmd:APLABOUT, BAR, ESCAPE, KEY, MACHELP, PAD, PAGE, READERROR> <*any*> => __VfpUnsupported( <"udc"> )
+
+// ON EXIT variants (more specific, defined later = tried first)
+#command ON EXIT <cmd:BAR, MENU, PAD, POPUP> <*any*> => __VfpUnsupported( <"udc"> )
+
+// ON SELECTION variants
+#command ON SELECTION <cmd:BAR, MENU, PAD, POPUP> <*any*> => __VfpUnsupported( <"udc"> )
+
+// ON KEY = (must precede generic ON KEY in match order)
+#command ON KEY = <*any*> => __VfpUnsupported( <"udc"> )
+
+// ON KEY LABEL (most specific = tried first)
+#command ON KEY LABEL <*any*> => __VfpUnsupported( <"udc"> )
+
 #ifndef NOASSERT
 #command ASSERT <expression> [MESSAGE <cMessageText>]  ;
         => __FoxAssert( <expression> , <"expression">, <cMessageText> )

--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -795,6 +795,11 @@
 #command SUSPEND <*any*> => __VfpUnsupported( <"udc"> )
 #command TYPE <*any*> => __VfpUnsupported( <"udc"> )
 
+#command EJECT <*any*> => __VfpUnsupported( <"udc"> )
+#command EJECT PAGE <*any*> => __VfpUnsupported( <"udc"> )
+#command PRINTJOB <*any*> => __VfpUnsupported( <"udc"> )
+#command ENDPRINTJOB <*any*> => __VfpUnsupported( <"udc"> )
+
 #ifndef NOASSERT
 #command ASSERT <expression> [MESSAGE <cMessageText>]  ;
         => __FoxAssert( <expression> , <"expression">, <cMessageText> )

--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -726,6 +726,16 @@
 // ON KEY LABEL (most specific = tried first)
 #command ON KEY LABEL <*any*> => __VfpUnsupported( <"udc"> )
 
+// CLEAR / RELEASE variants — Silent Absorption
+
+// CLEAR variants not already handled (ALL, MEMORY, SCREEN, EVENTS, RESOURCES are elsewhere)
+#command CLEAR <cmd:CLASS, CLASSLIB, DLLs, FIELDS, GETS, MACROS, MENUS, POPUPS, PROGRAM, PROMPT, READ, TYPEAHEAD, WINDOWS> <*any*> ;
+         => __VfpUnsupported( <"udc"> )
+
+// RELEASE UI variants (variable RELEASE is handled in memvar.xh)
+#command RELEASE <cmd:BAR, CLASSLIB, LIBRARY, MENUS, MODULE, PAD, POPUPS, PROCEDURE, WINDOWS> <*any*> ;
+         => __VfpUnsupported( <"udc"> )
+
 #ifndef NOASSERT
 #command ASSERT <expression> [MESSAGE <cMessageText>]  ;
         => __FoxAssert( <expression> , <"expression">, <cMessageText> )

--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -758,6 +758,43 @@
 #command DISPLAY <*any*> => __VfpUnsupported( <"udc"> )
 #command LIST <*any*> => __VfpUnsupported( <"udc"> )
 
+// Database misc
+#command APPEND <cmd:GENERAL, MEMO, PROCEDURES> <*any*> => __VfpUnsupported( <"udc"> )
+#command BLANK <*any*> => __VfpUnsupported( <"udc"> )
+#command CALCULATE <*any*> => __VfpUnsupported( <"udc"> )
+#command CLOSE <cmd:DEBUGGER, FORMAT, MEMO, PRINTER, PROCEDURE> <*any*> => __VfpUnsupported( <"udc"> )
+#command COPY <cmd:INDEXES, PROCEDURES, TAG> <*any*> => __VfpUnsupported( <"udc"> )
+#command DELETE <cmd:TRIGGER, VIEW> <*any*> => __VfpUnsupported( <"udc"> )
+#command FLUSH <*any*> => __VfpUnsupported( <"udc"> )
+#command FREE TABLE <*any*> => __VfpUnsupported( <"udc"> )
+#command PACK DATABASE <*any*> => __VfpUnsupported( <"udc"> )
+#command REMOVE CLASS <*any*> => __VfpUnsupported( <"udc"> )
+#command RENAME <cmd:CLASS, CONNECTION, VIEW> <*any*> => __VfpUnsupported( <"udc"> )
+#command REPLACE FROM ARRAY <*any*> => __VfpUnsupported( <"udc"> )
+#command VALIDATE DATABASE <*any*> => __VfpUnsupported( <"udc"> )
+
+// System / legacy
+#command CALL <*any*> => __VfpUnsupported( <"udc"> )
+#command DOEVENTS <*any*> => __VfpUnsupported( <"udc"> )
+#command EXPORT <*any*> => __VfpUnsupported( <"udc"> )
+#command GETEXPR <*any*> => __VfpUnsupported( <"udc"> )
+#command HELP <*any*> => __VfpUnsupported( <"udc"> )
+#command IMPORT <*any*> => __VfpUnsupported( <"udc"> )
+#command INPUT <*any*> => __VfpUnsupported( <"udc"> )
+#command LOAD <*any*> => __VfpUnsupported( <"udc"> )
+#command LOGOUT <*any*> => __VfpUnsupported( <"udc"> )
+#command PLAY MACRO <*any*> => __VfpUnsupported( <"udc"> )
+#command POP KEY <*any*> => __VfpUnsupported( <"udc"> )
+#command PUSH KEY <*any*> => __VfpUnsupported( <"udc"> )
+#command REGIONAL <*any*> => __VfpUnsupported( <"udc"> )
+#command RESET <*any*> => __VfpUnsupported( <"udc"> )
+#command RESTORE <cmd:MACROS, SCREEN, WINDOW> <*any*> => __VfpUnsupported( <"udc"> )
+#command RUNSCRIPT <*any*> => __VfpUnsupported( <"udc"> )
+#command SAVE <cmd:MACROS, SCREEN, WINDOW> <*any*> => __VfpUnsupported( <"udc"> )
+#command SCROLL <*any*> => __VfpUnsupported( <"udc"> )
+#command SUSPEND <*any*> => __VfpUnsupported( <"udc"> )
+#command TYPE <*any*> => __VfpUnsupported( <"udc"> )
+
 #ifndef NOASSERT
 #command ASSERT <expression> [MESSAGE <cMessageText>]  ;
         => __FoxAssert( <expression> , <"expression">, <cMessageText> )

--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -671,6 +671,46 @@
 #command MODIFY <cmd:COMMAND, CLASS, DATABASE, CONNECTION, FILE, FORM, GENERAL, LABEL, MEMO, MENU, PROCEDURE, PROJECT, QUERY, REPORT, SCREEN, STRUCTURE, WINDOW>  <*any*> ;
             => __VfpUnsupported( <"udc"> )
 
+// @... command (all variants: SAY, GET, BOX, CLEAR, EDIT, FILL, MENU, PROMPT, SCROLL, TO, CLASS)
+#command @ <*any*> => __VfpUnsupported( <"udc"> )
+
+// ACTIVATE - menus, popups, screens, user-defined windows
+#command ACTIVATE <cmd:MENU, POPUP, SCREEN, WINDOW> <*any*> => __VfpUnsupported( <"udc"> )
+
+// DEACTIVATE
+#command DEACTIVATE <cmd:MENU, POPUP, WINDOW> <*any*> => __VfpUnsupported( <"udc"> )
+
+// DEFINE - UI elements (excludes DEFINE CLASS)
+#command DEFINE <cmd:BAR, BOX, MENU, PAD, POPUP, WINDOW> <*any*> => __VfpUnsupported( <"udc"> )
+
+// HIDE
+#command HIDE <cmd:MENU, POPUP, WINDOW> <*any*> => __VfpUnsupported( <"udc"> )
+
+// MOVE
+#command MOVE <cmd:POPUP, WINDOW> <*any*> => __VfpUnsupported( <"udc"> )
+
+// POP
+#command POP <cmd:MENU, POPUP> <*any*> => __VfpUnsupported( <"udc"> )
+
+// SHOW
+#command SHOW <cmd:GET, GETS, MENU, OBJECT, POPUP, WINDOW> <*any*> => __VfpUnsupported( <"udc"> )
+
+// SIZE
+#command SIZE <cmd:POPUP, WINDOW> <*any*> => __VfpUnsupported( <"udc"> )
+
+// Individual UI/browser commands
+#command BROWSE <*any*> => __VfpUnsupported( <"udc"> )
+#command CHANGE <*any*> => __VfpUnsupported( <"udc"> )
+#command EDIT <*any*> => __VfpUnsupported( <"udc"> )
+#command KEYBOARD <*any*> => __VfpUnsupported( <"udc"> )
+#command MOUSE <*any*> => __VfpUnsupported( <"udc"> )
+#command ZOOM WINDOW <*any*> => __VfpUnsupported( <"udc"> )
+#command READ MENU <*any*> => __VfpUnsupported( <"udc"> )
+
+// MENU
+#command MENU <*any*> => __VfpUnsupported( <"udc"> )
+#command MENU TO <*any*> => __VfpUnsupported( <"udc"> )
+
 #ifndef NOASSERT
 #command ASSERT <expression> [MESSAGE <cMessageText>]  ;
         => __FoxAssert( <expression> , <"expression">, <cMessageText> )

--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -726,8 +726,6 @@
 // ON KEY LABEL (most specific = tried first)
 #command ON KEY LABEL <*any*> => __VfpUnsupported( <"udc"> )
 
-// CLEAR / RELEASE variants — Silent Absorption
-
 // CLEAR variants not already handled (ALL, MEMORY, SCREEN, EVENTS, RESOURCES are elsewhere)
 #command CLEAR <cmd:CLASS, CLASSLIB, DLLs, FIELDS, GETS, MACROS, MENUS, POPUPS, PROGRAM, PROMPT, READ, TYPEAHEAD, WINDOWS> <*any*> ;
          => __VfpUnsupported( <"udc"> )
@@ -735,6 +733,30 @@
 // RELEASE UI variants (variable RELEASE is handled in memvar.xh)
 #command RELEASE <cmd:BAR, CLASSLIB, LIBRARY, MENUS, MODULE, PAD, POPUPS, PROCEDURE, WINDOWS> <*any*> ;
          => __VfpUnsupported( <"udc"> )
+
+// DISPLAY variants
+#command DISPLAY [<cmd:CONNECTIONS, DATABASE, DLLS, FILES, HISTORY, MEMORY>] <*any*> ;
+         => __VfpUnsupported( <"udc"> )
+
+#command DISPLAY <cmd:OBJECTS, PROCEDURES, STATUS, STRUCTURE, TABLES, VIEWS> <*any*> ;
+         => __VfpUnsupported( <"udc"> )
+
+// DISPLAY USERS / LIST USERS
+#command DISPLAY USERS <*any*> => __VfpUnsupported( <"udc"> )
+
+// LIST variants
+#command LIST [<cmd:CONNECTIONS, DATABASE, DLLS, FILES, HISTORY, MEMORY>] <*any*> ;
+         => __VfpUnsupported( <"udc"> )
+
+#command LIST <cmd:OBJECTS, PROCEDURES, STATUS, STRUCTURE, TABLES, VIEWS> <*any*> ;
+         => __VfpUnsupported( <"udc"> )
+
+// LIST USERS
+#command LIST USERS <*any*> => __VfpUnsupported( <"udc"> )
+
+// Plain DISPLAY and LIST (no sub-command)
+#command DISPLAY <*any*> => __VfpUnsupported( <"udc"> )
+#command LIST <*any*> => __VfpUnsupported( <"udc"> )
 
 #ifndef NOASSERT
 #command ASSERT <expression> [MESSAGE <cMessageText>]  ;

--- a/src/Common/FoxProSet.xh
+++ b/src/Common/FoxProSet.xh
@@ -122,6 +122,18 @@
 #command SET COLOR SET                                          <*any*> => __UNSUPPORTED__ <(udc)>
 #command SET DATASESSION                                        <*any*> => __UNSUPPORTED__ <(udc)>
 
+// Remaining VFP SET commands — Silent Absorption
+#command SET <x:APLABOUT, ATTRIBUTES, BLINK, BORDER>             <*any*> => __UNSUPPORTED__ <(udc)>
+#command SET <x:BRSTATUS, CATALOG, CLEAR, DBTRAP>                 <*any*> => __UNSUPPORTED__ <(udc)>
+#command SET <x:DESIGN, ENCRYPTION, HELPFILTER, HISTORY>          <*any*> => __UNSUPPORTED__ <(udc)>
+#command SET <x:IBLOCK, INSTRUCT, LDCHECK>                        <*any*> => __UNSUPPORTED__ <(udc)>
+#command SET <x:MACDESKTOP, MACHELP, MARK OF, MARK TO>            <*any*> => __UNSUPPORTED__ <(udc)>
+#command SET <x:MBLOCK, MENU, MOUSE, PAUSE>                       <*any*> => __UNSUPPORTED__ <(udc)>
+#command SET <x:PRECISION, PRINTER TO, RELATION OFF, REPROCESS>   <*any*> => __UNSUPPORTED__ <(udc)>
+#command SET <x:SCOREBOARD, SHADOWS, SKIP OF, SQL>                <*any*> => __UNSUPPORTED__ <(udc)>
+#command SET <x:STATUS BAR, STICKY, TITLE, TOPIC ID>              <*any*> => __UNSUPPORTED__ <(udc)>
+#command SET <x:TRAP, WINDOW OF MEMO, XCMDFILE>                   <*any*> => __UNSUPPORTED__ <(udc)>
+
 #endif
 
 // EOF

--- a/src/Runtime/XSharp.VFP/Classes/PropertyContainer.prg
+++ b/src/Runtime/XSharp.VFP/Classes/PropertyContainer.prg
@@ -150,10 +150,10 @@ class XSharp.VFP.PropertyContainer IMPLEMENTS IEnumerable<NameValuePair>
     virtual method NoIvarPut(cName as string, uValue as usual) as void
         if _Properties:TryGetValue( cName, out var desc)
             if desc:PropInfo is PropertyInfo var oProp
-                oProp:SetValue(_Owner, uValue)
+                oProp:SetValue(_Owner, OOPHelpers.ValueConvert(uValue, oProp:PropertyType))
                 return
             elseif desc:PropInfo is FieldInfo var oFld
-                oFld:SetValue(_Owner, uValue)
+                oFld:SetValue(_Owner, OOPHelpers.ValueConvert(uValue, oFld:FieldType))
                 return
             elseif self:_Values:ContainsKey(cName)
                 self:_Values[cName] := uValue


### PR DESCRIPTION
Absorbs aproximaterly 230 commands that have no functional equivalente in XSharp. Commands that already had functional implementations are left untouched.

## Motivation
During VFP-to-X# migrations, user will encounter compiler errors for unsupported VFP commands even when those commands serve no purpose in the .NET runtime ej: IDE commands, legacy UI, old menu system). This creates noisy migration output and requires manual cleanup of every instance.

By absorbing these commands as silent NOPs, they compile without error and become invisible at runtime allowing developers to focus on commands that actually need porting attention.