### PR TITLE
FoxPro subclasses without INIT now forward CREATEOBJECT() args to parent

### DIFF
--- a/src/Compiler/src/Compiler/XSharpCodeAnalysis/Parser/XSharpTreeTransformationFox.cs
+++ b/src/Compiler/src/Compiler/XSharpCodeAnalysis/Parser/XSharpTreeTransformationFox.cs
@@ -1124,6 +1124,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     ctor.XGenerated = true;
                 }
             }
+            else
+            {
+                // Subclass without its own INIT: VFP calls the parent's INIT
+                // with all the arguments passed to CREATEOBJECT(). Generate a
+                // Clipper-calling-convention constructor that forwards
+                // _ClipperArgs to the base class constructor, so the parent
+                // INIT receives the arguments instead of getting NIL/empty.
+                ParameterListSyntax pars = GetClipperParameters();
+                var arg = MakeArgument(GenerateSimpleName(XSharpSpecialNames.ClipperArgs));
+                ArgumentListSyntax args = MakeArgumentList(arg);
+                var chain = _syntaxFactory.ConstructorInitializer(SyntaxKind.BaseConstructorInitializer,
+                                                                    SyntaxFactory.ColonToken,
+                                                                    SyntaxFactory.MakeToken(SyntaxKind.BaseKeyword),
+                                                                    args
+                                                                    );
+                var mods = TokenList(SyntaxKind.PublicKeyword);
+                var id = context.Id.Get<SyntaxToken>();
+                GenerateAttributeList(attributeLists, SystemQualifiedNames.CompilerGenerated);
+                attributeLists.Add(MakeClipperCallingConventionAttribute(new List<ExpressionSyntax>()));
+                var body = MakeBlock(stmts);
+                ctor = _syntaxFactory.ConstructorDeclaration(attributeLists, mods, id, pars, chain, body, null, null);
+                ctor.XGenerated = true;
+            }
             _pool.Free(attributeLists);
             return ctor;
         }


### PR DESCRIPTION
In VFP9, when a subclass does not define its own `Init`, the engine automatically calls the parent class's `Init` with all the arguments passes to `CREATEOBJECT()`. This is one of the most basic OOP patterns in FoxPro:

```xBase
loDog = createobject("Dog", "Rex")
? loDog._name
return

define class Animal as Custom
    _name = ""
    procedure Init(tcName)
        this._name = tcName
    endproc
enddefine

define class Dog as Animal
    && no Init defined
enddefine
```

In XSharp, `createConstructor` (XSharpTreeTransformationFox.cs) only generated a constructor for a Fox class when that class itself defined `Init` (or `AddObject` / an existing ctor). Then a subclass had none of these, no constructor was generated at all, so .NET emitted a defalt parameterless constructor calling `base()`. Any arguments passed to `CREATEOBJECT()` where silently dropped, the parent's `Init` ran with NIL parameters, and properties initialized from those parameters stayed NIL, causing runtime errors.
