### PR TITLE
full support for WAIT WINDOW command

### DIFF
--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -162,6 +162,56 @@
 #command DIR               => __VfpDir( "" )
 #command DIRECTORY         => __VfpDir( "" )
 
+#xcommand WAIT <msg> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
+    => __VfpWait(<msg>, <.win.>, -1, -1, <.now.>, <.nclr.>, -1)
+
+#xcommand WAIT <msg> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
+    => __VfpWait(<msg>, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, -1)
+
+#xcommand WAIT <msg> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
+    => __VfpWait(<msg>, <.win.>, -1, -1, <.now.>, <.nclr.>, <secs>)
+
+#xcommand WAIT <msg> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
+    => __VfpWait(<msg>, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, <secs>)
+
+#xcommand WAIT <msg> TO <v> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
+    => <V> := __VfpWait(<msg>, <.win.>, -1, -1, <.now.>, <.nclr.>, -1)
+
+#xcommand WAIT <msg> TO <v> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
+    => <V> := __VfpWait(<msg>, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, -1)
+
+#xcommand WAIT <msg> TO <v> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
+    => <V> := __VfpWait(<msg>, <.win.>, -1, -1, <.now.>, <.nclr.>, <secs>)
+
+#xcommand WAIT <msg> TO <v> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
+    => <V> := __VfpWait(<msg>, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, <secs>)
+
+#xcommand WAIT [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
+    => __VfpWait(NULL, <.win.>, -1, -1, <.now.>, <.nclr.>, -1)
+
+#xcommand WAIT <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
+    => __VfpWait(NULL, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, -1)
+
+#xcommand WAIT [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
+    => __VfpWait(NULL, <.win.>, -1, -1, <.now.>, <.nclr.>, <secs>)
+
+#xcommand WAIT <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
+    => __VfpWait(NULL, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, <secs>)
+
+#xcommand WAIT TO <v> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
+    => <V> := __VfpWait(NULL, <.win.>, -1, -1, <.now.>, <.nclr.>, -1)
+
+#xcommand WAIT TO <v> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
+    => <V> := __VfpWait(NULL, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, -1)
+
+#xcommand WAIT TO <v> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
+    => <V> := __VfpWait(NULL, <.win.>, -1, -1, <.now.>, <.nclr.>, <secs>)
+
+#xcommand WAIT TO <v> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
+    => <V> := __VfpWait(NULL, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, <secs>)
+
+#xcommand WAIT CLEAR => __VfpWaitClear()
+
 // Commands with IN clause, commands without are defined in DBCMD.XH
 
 #command REINDEX           IN <(a)>          => (<(a)>) -> (OrdListRebuild())

--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -162,53 +162,18 @@
 #command DIR               => __VfpDir( "" )
 #command DIRECTORY         => __VfpDir( "" )
 
-#xcommand WAIT <msg> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
-    => __VfpWait(<msg>, <.win.>, -1, -1, <.now.>, <.nclr.>, -1)
+// WAIT
+#xcommand WAIT <msg> [<win:WINDOW> [AT <nRow>, <nCol>]] [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
+    => __VfpWait(<msg>, <.win.>, <!nRow!>, <!nCol!>, <.now.>, <.nclr.>, <!secs!>)
 
-#xcommand WAIT <msg> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
-    => __VfpWait(<msg>, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, -1)
+#xcommand WAIT <msg> TO <v> [<win:WINDOW> [AT <nRow>, <nCol>]] [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
+    => <v> := __VfpWait(<msg>, <.win.>, <!nRow!>, <!nCol!>, <.now.>, <.nclr.>, <!secs!>)
 
-#xcommand WAIT <msg> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
-    => __VfpWait(<msg>, <.win.>, -1, -1, <.now.>, <.nclr.>, <secs>)
+#xcommand WAIT [<win:WINDOW> [AT <nRow>, <nCol>]] [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
+    => __VfpWait(NIL, <.win.>, <!nRow!>, <!nCol!>, <.now.>, <.nclr.>, <!secs!>)
 
-#xcommand WAIT <msg> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
-    => __VfpWait(<msg>, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, <secs>)
-
-#xcommand WAIT <msg> TO <v> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
-    => <V> := __VfpWait(<msg>, <.win.>, -1, -1, <.now.>, <.nclr.>, -1)
-
-#xcommand WAIT <msg> TO <v> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
-    => <V> := __VfpWait(<msg>, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, -1)
-
-#xcommand WAIT <msg> TO <v> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
-    => <V> := __VfpWait(<msg>, <.win.>, -1, -1, <.now.>, <.nclr.>, <secs>)
-
-#xcommand WAIT <msg> TO <v> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
-    => <V> := __VfpWait(<msg>, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, <secs>)
-
-#xcommand WAIT [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
-    => __VfpWait(NULL, <.win.>, -1, -1, <.now.>, <.nclr.>, -1)
-
-#xcommand WAIT <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
-    => __VfpWait(NULL, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, -1)
-
-#xcommand WAIT [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
-    => __VfpWait(NULL, <.win.>, -1, -1, <.now.>, <.nclr.>, <secs>)
-
-#xcommand WAIT <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
-    => __VfpWait(NULL, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, <secs>)
-
-#xcommand WAIT TO <v> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
-    => <V> := __VfpWait(NULL, <.win.>, -1, -1, <.now.>, <.nclr.>, -1)
-
-#xcommand WAIT TO <v> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] ;
-    => <V> := __VfpWait(NULL, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, -1)
-
-#xcommand WAIT TO <v> [<win:WINDOW>] [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
-    => <V> := __VfpWait(NULL, <.win.>, -1, -1, <.now.>, <.nclr.>, <secs>)
-
-#xcommand WAIT TO <v> <win:WINDOW> AT <nRow>, <nCol> [<now:NOWAIT>] [<nclr:NOCLEAR>] TIMEOUT <secs> ;
-    => <V> := __VfpWait(NULL, .T., <nRow>, <nCol>, <.now.>, <.nclr.>, <secs>)
+#xcommand WAIT TO <v> [<win:WINDOW> [AT <nRow>, <nCol>]] [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
+    => <v> := __VfpWait(NIL, <.win.>, <!nRow!>, <!nCol!>, <.now.>, <.nclr.>, <!secs!>)
 
 #xcommand WAIT CLEAR => __VfpWaitClear()
 

--- a/src/Runtime/XSharp.VFP/Commands.prg
+++ b/src/Runtime/XSharp.VFP/Commands.prg
@@ -163,3 +163,60 @@ FUNCTION __VfpDir(cCommand AS STRING) AS VOID
         NOP
     ENDIF
 RETURN
+
+FUNCTION __VfpWait(uMsg AS USUAL, lWindow AS LOGIC, nRow AS INT, nCol AS INT, ;
+    lNoWait AS LOGIC, lNoClear AS LOGIC, nTimeout AS REAL8) AS STRING
+    LOCAL cMsg AS STRING
+
+    IF !Environment.UserInteractive
+        RETURN ""
+    ENDIF
+    IF uMsg == NULL
+        cMsg := IIF(lWindow, "", "Press any key to continue...")
+    ELSE
+        cMsg := AsString(uMsg)
+    ENDIF
+
+    IF Win32.GetConsoleWindow() != IntPtr.Zero
+        IF !String.IsNullOrEmpty(cMsg)
+            Console.WriteLine()
+            Console.Write(cMsg)
+        ENDIF
+        IF lNoWait
+            RETURN ""
+        ENDIF
+        RETURN __VfpWaitForKey(nTimeout)
+    ENDIF
+
+    IF lNoWait
+        RETURN ""
+    ENDIF
+    LOCAL nMsTimeout AS LONG
+    nMsTimeout := IIF(nTimeout > 0, (LONG)(nTimeout * 1000), 0)
+    VfpUIService.Provider:ShowMessageBox(cMsg, 0, "Wait", nMsTimeout)
+    RETURN ""
+
+function __VfpWaitForKey(nTimeout as real8) as string
+    local info as ConsoleKeyInfo
+
+    try
+        if nTimeout <= 0
+            info := Console.ReadKey(TRUE)
+            return info:KeyChar:ToString()
+        endif
+
+        var nEndTicks := Environment.TickCount + (int)(nTimeout * 1000)
+        do while Environment.TickCount < nEndTicks
+            if Console.KeyAvailable
+                info := Console.ReadKey(TRUE)
+                return info:KeyChar:ToString()
+            endif
+            System.Threading.Thread.Sleep(50)
+        enddo
+        return ""
+    catch as System.InvalidOperationException
+        return ""
+    end try
+
+function __VfpWaitClear() as void
+    return

--- a/src/Runtime/XSharp.VFP/Commands.prg
+++ b/src/Runtime/XSharp.VFP/Commands.prg
@@ -164,14 +164,16 @@ FUNCTION __VfpDir(cCommand AS STRING) AS VOID
     ENDIF
 RETURN
 
-FUNCTION __VfpWait(uMsg AS USUAL, lWindow AS LOGIC, nRow AS INT, nCol AS INT, ;
-    lNoWait AS LOGIC, lNoClear AS LOGIC, nTimeout AS REAL8) AS STRING
+FUNCTION __VfpWait(uMsg AS USUAL, lWindow AS LOGIC, uRow AS USUAL, uCol AS USUAL, ;
+    lNoWait AS LOGIC, lNoClear AS LOGIC, uTimeout AS USUAL) AS STRING
+
     LOCAL cMsg AS STRING
 
     IF !Environment.UserInteractive
         RETURN ""
     ENDIF
-    IF uMsg == NULL
+
+    IF IsNil(uMsg)
         cMsg := IIF(lWindow, "", "Press any key to continue...")
     ELSE
         cMsg := AsString(uMsg)
@@ -185,38 +187,40 @@ FUNCTION __VfpWait(uMsg AS USUAL, lWindow AS LOGIC, nRow AS INT, nCol AS INT, ;
         IF lNoWait
             RETURN ""
         ENDIF
-        RETURN __VfpWaitForKey(nTimeout)
+        RETURN __VfpWaitForKey(uTimeout)
     ENDIF
 
     IF lNoWait
         RETURN ""
     ENDIF
     LOCAL nMsTimeout AS LONG
-    nMsTimeout := IIF(nTimeout > 0, (LONG)(nTimeout * 1000), 0)
+    nMsTimeout := IIF(IsNil(uTimeout), 0, (LONG)((REAL8) uTimeout * 1000))
     VfpUIService.Provider:ShowMessageBox(cMsg, 0, "Wait", nMsTimeout)
     RETURN ""
 
-function __VfpWaitForKey(nTimeout as real8) as string
-    local info as ConsoleKeyInfo
+FUNCTION __VfpWaitForKey(uTimeout AS USUAL) AS STRING
+    LOCAL info AS ConsoleKeyInfo
 
-    try
-        if nTimeout <= 0
+    TRY
+        IF IsNil(uTimeout)
             info := Console.ReadKey(TRUE)
-            return info:KeyChar:ToString()
-        endif
+            Console.WriteLine()
+            RETURN info:KeyChar:ToString()
+        ENDIF
 
-        var nEndTicks := Environment.TickCount + (int)(nTimeout * 1000)
-        do while Environment.TickCount < nEndTicks
-            if Console.KeyAvailable
+        VAR nEndTicks := Environment.TickCount + (INT)((REAL8) uTimeout * 1000)
+        DO WHILE Environment.TickCount < nEndTicks
+            IF Console.KeyAvailable
                 info := Console.ReadKey(TRUE)
-                return info:KeyChar:ToString()
-            endif
+                Console.WriteLine()
+                RETURN info:KeyChar:ToString()
+            ENDIF
             System.Threading.Thread.Sleep(50)
-        enddo
-        return ""
-    catch as System.InvalidOperationException
-        return ""
-    end try
+        ENDDO
+        RETURN ""
+    CATCH AS System.InvalidOperationException
+        RETURN ""
+    END TRY
 
 function __VfpWaitClear() as void
     return

--- a/src/Runtime/XSharp.VFP/Win32.prg
+++ b/src/Runtime/XSharp.VFP/Win32.prg
@@ -25,6 +25,8 @@ BEGIN NAMESPACE XSharp.VFP
         [DllImport("user32.dll", CharSet := CharSet.Auto, ExactSpelling := TRUE, SetLastError := TRUE)];
         PUBLIC STATIC EXTERN METHOD GetSystemMetrics(nIndex AS INT) AS INT
 
+        [DllImport("kernel32.dll")];
+        PUBLIC STATIC EXTERN METHOD GetConsoleWindow() AS IntPtr
     END CLASS
 
 END NAMESPACE


### PR DESCRIPTION
Fixes #1992 

Added full support for WAIT WINDOW.

## Changes

- `FoxProCmd.xh`: UDC rules for covering all valid WAIT syntax combinations: `WINDOW`, `AT nRow, nCol`, `NOWAIT`, `NOCLEAR`, `TIMEOUT nSeconds`, `TO VarName` and `WAIT CLEAR`.
- `Commands.prg`: Added runtime function `__VfpWait` with behavior adapter per environment: console apps wait for a keypress (respecting TIMEOUT), GUI desktop host show a message dialog _(this may change in the future but is ok for now)_, and non-interactive environments like services or libraries, absorb the command silently.
- `Win32.prg`: Added `GetConsoleWindow()` P/Invoke to distinguish console host from GUI hosts at runtime.