### PR TITLE
Implement GETPRINTER, PUTFILE, LOCFILE and INPUTBOX

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/OtherTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/OtherTests.prg
@@ -236,9 +236,60 @@ BEGIN NAMESPACE XSharp.VFP.Tests
                     File.Delete(cTempFile)
                 ENDIF
             END TRY
+        END METHOD
 
+        [Fact];
+        METHOD GetPrinterHeadlessReturnsEmpty() AS VOID
+            VAR oPrev := VfpUIService.Provider
+            TRY
+                VfpUIService.Provider := HeadlessUIProvider{}
+                Assert.Equal("", GetPrinter())
+            FINALLY
+                VfpUIService.Provider := oPrev
+            END TRY
+        END METHOD
 
+        [Fact];
+        METHOD PutFileHeadlessReturnsEmpty() AS VOID
+            VAR oPrev := VfpUIService.Provider
+            TRY
+                VfpUIService.Provider := HeadlessUIProvider{}
+                Assert.Equal("", PutFile("Save as:", "test.txt", "TXT"))
+            FINALLY
+                VfpUIService.Provider := oPrev
+            END TRY
+        END METHOD
 
+        [Fact];
+        METHOD LocFileExistingFileReturnsPath() AS VOID
+            VAR cTemp := System.IO.Path.GetTempFileName()
+            TRY
+                Assert.Equal(cTemp, LocFile(cTemp))
+            FINALLY
+                System.IO.File.Delete(cTemp)
+            END TRY
+        END METHOD
+
+        [Fact];
+        METHOD LocFileNotFoundHeadlessThrows() AS VOID
+            VAR oPrev := VfpUIService.Provider
+            TRY
+                VfpUIService.Provider := HeadlessUIProvider{}
+                Assert.Throws<XSharp.Error>({ => LocFile("C:\\nonexistent_xyz_12345.zzz") })
+            FINALLY
+                VfpUIService.Provider := oPrev
+            END TRY
+        END METHOD
+
+        [Fact];
+        METHOD InputBoxHeadlessReturnsCancelValue() AS VOID
+            VAR oPrev := VfpUIService.Provider
+            TRY
+                VfpUIService.Provider := HeadlessUIProvider{}
+                Assert.Equal("CANCELLED", InputBox("Prompt", "Title", "default", 0, "TIMEOUT", "CANCELLED"))
+            FINALLY
+                VfpUIService.Provider := oPrev
+            END TRY
         END METHOD
 	END CLASS
 

--- a/src/Runtime/XSharp.VFP.UI/InputBoxForm.prg
+++ b/src/Runtime/XSharp.VFP.UI/InputBoxForm.prg
@@ -1,0 +1,108 @@
+﻿//
+// Copyright (c) XSharp B.V.  All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+// See License.txt in the project root for license information.
+//
+
+USING System
+USING System.Drawing
+USING System.Windows.Forms
+
+BEGIN NAMESPACE XSharp.VFP.UI
+
+    /// <summary>
+    /// Modal dialog that supports the VFP function INPUTBOX(): prompt + text box,
+    /// OK/Cancel buttons and an optional timeout.
+    /// </summary>
+    INTERNAL CLASS InputBoxForm INHERIT System.Windows.Forms.Form
+        PRIVATE _txtInput     AS System.Windows.Forms.TextBox
+        PRIVATE _timer        AS System.Windows.Forms.Timer
+        PRIVATE _timedOut     := FALSE AS LOGIC
+        PRIVATE _timeoutValue AS STRING
+        PRIVATE _cancelValue  AS STRING
+
+        PUBLIC CONSTRUCTOR(cPrompt AS STRING, cCaption AS STRING, cDefault AS STRING, ;
+                           nTimeout AS LONG, cTimeoutValue AS STRING, cCancelValue AS STRING) STRICT
+            SUPER()
+            SELF:_timeoutValue := cTimeoutValue
+            SELF:_cancelValue  := cCancelValue
+            SELF:BuildLayout(cPrompt, cCaption, cDefault)
+
+            IF nTimeout > 0
+                SELF:_timer          := System.Windows.Forms.Timer{}
+                SELF:_timer:Interval := nTimeout
+                SELF:_timer:Tick     += System.EventHandler{ SELF, @OnTimerTick() }
+                SELF:_timer:Start()
+            ENDIF
+            RETURN
+
+        PRIVATE METHOD BuildLayout(cPrompt AS STRING, cCaption AS STRING, cDefault AS STRING) AS VOID STRICT
+            SELF:SuspendLayout()
+
+            VAR oLabel := System.Windows.Forms.Label{}
+            oLabel:AutoSize := FALSE
+            oLabel:Location := System.Drawing.Point{12, 14}
+            oLabel:Size     := System.Drawing.Size{410, 20}
+            oLabel:Text     := cPrompt
+
+            SELF:_txtInput          := System.Windows.Forms.TextBox{}
+            SELF:_txtInput:Location := System.Drawing.Point{12, 36}
+            SELF:_txtInput:Size     := System.Drawing.Size{410, 23}
+            SELF:_txtInput:Text     := cDefault
+
+            VAR oOk := System.Windows.Forms.Button{}
+            oOk:Text         := "OK"
+            oOk:DialogResult := System.Windows.Forms.DialogResult.OK
+            oOk:Location     := System.Drawing.Point{266, 72}
+            oOk:Size         := System.Drawing.Size{75, 25}
+
+            VAR oCancel := System.Windows.Forms.Button{}
+            oCancel:Text         := "Cancel"
+            oCancel:DialogResult := System.Windows.Forms.DialogResult.Cancel
+            oCancel:Location     := System.Drawing.Point{347, 72}
+            oCancel:Size         := System.Drawing.Size{75, 25}
+
+            SELF:Controls:Add(oLabel)
+            SELF:Controls:Add(SELF:_txtInput)
+            SELF:Controls:Add(oOk)
+            SELF:Controls:Add(oCancel)
+
+            SELF:AcceptButton    := oOk
+            SELF:CancelButton    := oCancel
+            SELF:Text            := cCaption
+            SELF:FormBorderStyle := System.Windows.Forms.FormBorderStyle.FixedDialog
+            SELF:StartPosition   := System.Windows.Forms.FormStartPosition.CenterScreen
+            SELF:MaximizeBox     := FALSE
+            SELF:MinimizeBox     := FALSE
+            SELF:ShowIcon        := FALSE
+            SELF:ShowInTaskbar   := FALSE
+            SELF:ClientSize      := System.Drawing.Size{434, 110}
+
+            SELF:ResumeLayout(FALSE)
+            SELF:_txtInput:SelectAll()
+            RETURN
+
+        PRIVATE METHOD OnTimerTick(sender AS OBJECT, e AS System.EventArgs) AS VOID STRICT
+            SELF:_timer:Stop()
+            SELF:_timedOut := TRUE
+            SELF:Close()
+            RETURN
+
+        PUBLIC METHOD GetResult() AS STRING STRICT
+            IF SELF:_timedOut
+                RETURN SELF:_timeoutValue
+            ELSEIF SELF:DialogResult == System.Windows.Forms.DialogResult.OK
+                RETURN SELF:_txtInput:Text
+            ENDIF
+            RETURN SELF:_cancelValue
+
+        PROTECTED OVERRIDE METHOD Dispose(disposing AS LOGIC) AS VOID STRICT
+            IF disposing .AND. SELF:_timer != NULL
+                SELF:_timer:Dispose()
+            ENDIF
+            SUPER:Dispose(disposing)
+            RETURN
+
+    END CLASS
+
+END NAMESPACE

--- a/src/Runtime/XSharp.VFP.UI/VfpUIProvider.prg
+++ b/src/Runtime/XSharp.VFP.UI/VfpUIProvider.prg
@@ -275,6 +275,10 @@ BEGIN NAMESPACE XSharp.VFP.UI
             RETURN {}
         END METHOD
 
+        PUBLIC METHOD GetPrinter() AS STRING
+            RETURN VfpWin32UI.ShowPrintSetup(IntPtr.Zero)
+        END METHOD
+
         METHOD LoadPicture(cFileName AS STRING) AS OBJECT
             LOCAL oImage AS OBJECT
 
@@ -351,6 +355,32 @@ BEGIN NAMESPACE XSharp.VFP.UI
 
             RETURN ""
         END METHOD
+
+        PUBLIC METHOD PutFile(cCustomText AS STRING, cFileName AS STRING, cFileExtensions AS STRING) AS STRING
+            VAR oDlg := SaveFileDialog{}
+
+            IF !String.IsNullOrEmpty(cCustomText)
+                oDlg:Title := cCustomText
+            ENDIF
+
+            IF !String.IsNullOrEmpty(cFileName)
+                oDlg:FileName := cFileName
+            ENDIF
+
+            oDlg:Filter := SELF:ParsePutFileFilter(cFileExtensions)
+
+            VAR cDefExt := SELF:FirstExtension(cFileExtensions)
+            IF !String.IsNullOrEmpty(cDefExt)
+                oDlg:DefaultExt   := cDefExt
+                oDlg:AddExtension := TRUE
+            ENDIF
+
+            IF oDlg:ShowDialog() == DialogResult.OK
+                RETURN oDlg:FileName
+            ENDIF
+
+            RETURN ""
+        END METHOD
         #endregion
 
         #region Private Helper: Filter Parser
@@ -414,6 +444,44 @@ BEGIN NAMESPACE XSharp.VFP.UI
             ENDIF
 
             RETURN sb:ToString()
+        END METHOD
+
+        // Filter syntax of PUTFILE (just extensions, no descriptions):
+        //   ""        -> all files
+        //   "PRG"     -> just .prg
+        //   ";"       -> file with no extension
+        //   wilcards (*, ?) are allowed
+        PRIVATE METHOD ParsePutFileFilter(cExt AS STRING) AS STRING
+            IF String.IsNullOrEmpty(cExt)
+                RETURN "All Files (*.*)|*.*"
+            ENDIF
+
+            VAR aExts := cExt:Split(<CHAR>{c';', c'|'})
+            VAR cPatterns := ""
+            FOREACH cRaw AS STRING IN aExts
+                VAR cE  := cRaw:Trim()
+                VAR cPat := IIF(cE:Length == 0, "*.", "*." + cE)
+                cPatterns += IIF(cPatterns:Length > 0, ";", "") + cPat
+            NEXT
+
+            IF cPatterns:Length == 0
+                RETURN "All Files (*.*)|*.*"
+            ENDIF
+            RETURN "Files (" + cPatterns + ")|" + cPatterns
+        END METHOD
+
+        PRIVATE METHOD FirstExtension(cExt AS STRING) AS STRING
+            IF String.IsNullOrEmpty(cExt)
+                RETURN ""
+            ENDIF
+            VAR aExts := cExt:Split(<CHAR>{c';', c'|'})
+            FOREACH cRaw AS STRING IN aExts
+                VAR cE := cRaw:Trim()
+                IF cE:Length > 0 .AND. cE:IndexOfAny(<CHAR>{c'*', c'?'}) < 0
+                    RETURN cE
+                ENDIF
+            NEXT
+            RETURN ""
         END METHOD
         #endregion
 
@@ -500,6 +568,14 @@ BEGIN NAMESPACE XSharp.VFP.UI
             END TRY
 
             return nResult
+        END METHOD
+
+        PUBLIC METHOD InputBox(cInputPrompt AS STRING, cDialogCaption AS STRING, cDefaultValue AS STRING, ;
+                               nTimeout AS LONG, cTimeoutValue AS STRING, cCancelValue AS STRING) AS STRING
+            BEGIN USING VAR oForm := InputBoxForm{cInputPrompt, cDialogCaption, cDefaultValue, nTimeout, cTimeoutValue, cCancelValue}
+                oForm:ShowDialog()
+                RETURN oForm:GetResult()
+            END USING
         END METHOD
     END CLASS
 

--- a/src/Runtime/XSharp.VFP.UI/Win32UI.prg
+++ b/src/Runtime/XSharp.VFP.UI/Win32UI.prg
@@ -10,8 +10,67 @@ USING System.Runtime.InteropServices
 BEGIN NAMESPACE XSharp.VFP.UI
 
     INTERNAL STATIC CLASS VfpWin32UI
+        // GetPrinter settings
         PUBLIC CONST DESKTOP_HORZRES := 117 AS INT
         PUBLIC CONST DESKTOP_VERTRES := 118 AS INT
+        PUBLIC CONST PD_PRINTSETUP := 0x40U AS DWORD
+        [StructLayout(LayoutKind.Sequential, CharSet := CharSet.Unicode)];
+        PUBLIC STRUCT PRINTDLGW
+            PUBLIC lStructSize AS DWORD
+            PUBLIC hwndOwner AS IntPtr
+            PUBLIC hDevMode AS IntPtr
+            PUBLIC hDevNames AS IntPtr
+            PUBLIC hDC AS IntPtr
+            PUBLIC Flags AS DWORD
+            PUBLIC nFromPage AS WORD
+            PUBLIC nToPage AS WORD
+            PUBLIC nMinPage AS WORD
+            PUBLIC nMaxPage AS WORD
+            PUBLIC nCopies AS WORD
+            PUBLIC hInstance AS IntPtr
+            PUBLIC lCustData AS IntPtr
+            PUBLIC lpfnPrintHook AS IntPtr
+            PUBLIC lpfnSetupHook AS IntPtr
+            PUBLIC lpPrintTemplateName AS IntPtr
+            PUBLIC lpSetupTemplateName AS IntPtr
+            PUBLIC hPrintTemplate AS IntPtr
+            PUBLIC hSetupTemplate AS IntPtr
+        END STRUCT
+        [DllImport("comdlg32.dll", CharSet := CharSet.Unicode, SetLastError := TRUE, EntryPoint := "PrintDlgW")];
+        INTERNAL STATIC EXTERN METHOD PrintDlg(lppd REF PRINTDLGW) AS LOGIC
+        [DllImport("kernel32.dll")];
+        INTERNAL STATIC EXTERN METHOD GlobalLock(hMem AS IntPtr) AS IntPtr
+        [DllImport("kernel32.dll")];
+        [RETURN:MarshalAs(UnmanagedType.Bool)];
+        INTERNAL STATIC EXTERN METHOD GlobalUnlock(hMem AS IntPtr) AS LOGIC
+        [DllImport("kernel32.dll")];
+        INTERNAL STATIC EXTERN METHOD GlobalFree(hMem AS IntPtr) AS IntPtr
+
+        PUBLIC STATIC METHOD ShowPrintSetup(hwndOwner AS IntPtr) AS STRING
+            LOCAL pd AS PRINTDLGW
+            LOCAL cName := "" AS STRING
+            pd := PRINTDLGW{}
+            pd:lStructSize := (DWORD) Marshal.SizeOf(typeof(PRINTDLGW))
+            pd:hwndOwner   := hwndOwner
+            pd:Flags       := PD_PRINTSETUP
+            IF PrintDlg(REF pd)
+                IF pd:hDevNames != IntPtr.Zero
+                    VAR pLock := GlobalLock(pd:hDevNames)
+                    IF pLock != IntPtr.Zero
+                        TRY
+                            VAR wDeviceOffset := (INT) (WORD) Marshal.ReadInt16(pLock, 2)
+                            cName := Marshal.PtrToStringUni(IntPtr.Add(pLock, wDeviceOffset * 2))
+                        FINALLY
+                            GlobalUnlock(pd:hDevNames)
+                        END TRY
+                    ENDIF
+                ENDIF
+            ENDIF
+            IF pd:hDevMode  != IntPtr.Zero ; GlobalFree(pd:hDevMode)  ; ENDIF
+            IF pd:hDevNames != IntPtr.Zero ; GlobalFree(pd:hDevNames) ; ENDIF
+            RETURN IIF(cName == NULL, "", cName)
+        END METHOD
+        // GetPrinter settings
 
         [DllImport("user32.dll", CharSet := CharSet.Unicode, EntryPoint := "MessageBoxTimeoutW")] ;
         INTERNAL STATIC EXTERN METHOD MessageBoxTimeout( ;

--- a/src/Runtime/XSharp.VFP.UI/XSharp.VFP.UI.xsproj
+++ b/src/Runtime/XSharp.VFP.UI/XSharp.VFP.UI.xsproj
@@ -117,6 +117,7 @@
     <Compile Include="Generated\XMLAdapter.generated.prg" />
     <Compile Include="Generated\XMLField.generated.prg" />
     <Compile Include="Generated\XMLTable.generated.prg" />
+    <Compile Include="InputBoxForm.prg" />
     <Compile Include="MaskProvider.prg" />
     <Compile Include="Application.prg" />
     <Compile Include="Checkbox.prg" />

--- a/src/Runtime/XSharp.VFP/PrinterFunctions.prg
+++ b/src/Runtime/XSharp.VFP/PrinterFunctions.prg
@@ -53,3 +53,8 @@ FUNCTION PCol() AS LONG
 [FoxProFunction("PROW", FoxFunctionCategory.EnvironmentAndSystem, FoxEngine.RuntimeCore, FoxFunctionStatus.Full, FoxCriticality.Low)];
 FUNCTION PRow() AS LONG
     RETURN __FoxPrinterCol
+
+/// <include file="VFPDocs.xml" path="Runtimefunctions/getprinter/*" />
+[FoxProFunction("GETPRINTER", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Full, FoxCriticality.Medium)];
+FUNCTION GetPrinter() AS STRING
+    RETURN VfpUIService.Provider:GetPrinter()

--- a/src/Runtime/XSharp.VFP/ToDo-G.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-G.prg
@@ -40,13 +40,6 @@ FUNCTION GetObject( uType , cClassName) AS OBJECT
     // RETURN NULL_OBJECT
 
 /// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/getprinter/*" />
-[FoxProFunction("GETPRINTER", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Stub, FoxCriticality.Medium)];
-FUNCTION GetPrinter( ) AS STRING
-    THROW NotImplementedException{}
-    // RETURN ""
-
-/// <summary>-- todo --</summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/getresultset/*" />
 [FoxProFunction("GETRESULTSET", FoxFunctionCategory.SQL, FoxEngine.SQL, FoxFunctionStatus.Stub, FoxCriticality.Medium)];
 FUNCTION GetResultSet( ) AS LONG

--- a/src/Runtime/XSharp.VFP/ToDo-HI.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-HI.prg
@@ -13,13 +13,6 @@ FUNCTION InDbc( cDatabaseObjectName, cType ) AS LOGIC
     // RETURN FALSE
 
 /// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/inputbox/*" />
-[FoxProFunction("INPUTBOX", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Stub, FoxCriticality.High)];
-FUNCTION InputBox( cInputPrompt , cDialogCaption , cDefaultValue , nTimeout ,cTimeoutValue,cCancelValue) AS STRING
-    THROW NotImplementedException{}
-    // RETURN ""
-
-/// <summary>-- todo --</summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/istransactable/*" />
 [FoxProFunction("ISTRANSACTABLE", FoxFunctionCategory.Database, FoxEngine.WorkArea, FoxFunctionStatus.Stub, FoxCriticality.High)];
 FUNCTION IsTransactable( uArea ) AS LOGIC

--- a/src/Runtime/XSharp.VFP/ToDo-KLM.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-KLM.prg
@@ -12,16 +12,6 @@ FUNCTION KeyMatch(eIndexKey , nIndexNumber , uArea)  AS LOGIC
     THROW NotImplementedException{}
     // RETURN FALSE
 
-
-/// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/locfile/*" />
-// Example: = LOCFILE("","PRG File:prg;Compiled:fxp;Backup:bak","Bestand")
-[FoxProFunction("LOCFILE", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Stub, FoxCriticality.Medium)];
-FUNCTION LocFile( cFileName , cFileExtensions , cFileNameCaption ) AS STRING
-    THROW NotImplementedException{}
-    // RETURN ""
-
-
 /// <summary>-- todo --</summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/lookup/*" />
 [FoxProFunction("LOOKUP", FoxFunctionCategory.CursorAndTable, FoxEngine.WorkArea, FoxFunctionStatus.Stub, FoxCriticality.Medium)];

--- a/src/Runtime/XSharp.VFP/ToDo-NOP.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-NOP.prg
@@ -36,10 +36,3 @@ FUNCTION PrtInfo( nPrinterSetting , cPrinterName ) AS LONG
     THROW NotImplementedException{}
     // RETURN 0
 
-/// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/putfile/*" />
-[FoxProFunction("PUTFILE", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Stub, FoxCriticality.Medium)];
-FUNCTION PutFile( cCustomText , cFileName, cFileExtensions) AS STRING
-    THROW NotImplementedException{}
-    // RETURN ""
-

--- a/src/Runtime/XSharp.VFP/UI/Dialogs.prg
+++ b/src/Runtime/XSharp.VFP/UI/Dialogs.prg
@@ -5,6 +5,7 @@
 //
 
 USING System
+USING System.Collections.Generic
 USING XSharp.VFP
 
 INTERNAL DEFINE CF_NOSCRIPTSEL := 0x00800000L
@@ -38,4 +39,82 @@ END FUNCTION
 [FoxProFunction("GETPICT", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Full, FoxCriticality.Medium)];
 FUNCTION GetPict( cFileExtensions := "" AS STRING, cFileNameCaption := "" AS STRING, cOpenButtonCaption := "" AS STRING) AS STRING
     RETURN VfpUIService.Provider:GetPict(cFileExtensions, cFileNameCaption, cOpenButtonCaption)
+END FUNCTION
+
+/// <include file="VFPDocs.xml" path="Runtimefunctions/putfile/*" />
+[FoxProFunction("PUTFILE", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Full, FoxCriticality.Medium)];
+FUNCTION PutFile(cCustomText := "" AS STRING, cFileName := "" AS STRING, cFileExtensions := "" AS STRING) AS STRING
+    RETURN VfpUIService.Provider:PutFile(cCustomText, cFileName, cFileExtensions)
+END FUNCTION
+
+/// <include file="VFPDocs.xml" path="Runtimefunctions/locfile/*" />
+// Example: = LOCFILE("","PRG File:prg;Compiled:fxp;Backup:bak","Bestand")
+[FoxProFunction("LOCFILE", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Full, FoxCriticality.Medium)];
+FUNCTION LocFile(cFileName := "" AS STRING, cFileExtensions := "" AS STRING, cFileNameCaption := "" AS STRING) AS STRING
+
+    // We'll look into the hard drive first (curdir + SET PATH + SET DEFAULT), no UI
+    VAR cFound := __VfpLocFileSearch(cFileName, cFileExtensions)
+    IF !String.IsNullOrEmpty(cFound)
+        RETURN cFound
+    ENDIF
+
+    // If not found then we open a dialog (reuse GetFile with the same filter format)
+    VAR cResult := VfpUIService.Provider:GetFile(cFileExtensions, "", "", 0, cFileNameCaption)
+    IF !String.IsNullOrEmpty(cResult)
+        RETURN cResult
+    ENDIF
+
+    // Cancel/Esc: VFP generates an error and LOCFILE doesn't return any value
+    VAR err := Error{"File '" + cFileName + "' does not exist"}
+    err:Gencode     := Gencode.EG_OPEN
+    err:FuncSym     := "LOCFILE"
+    err:Description := err:Message
+    THROW err
+END FUNCTION
+
+// Search for the file as is, and if it doesn't have an extension, try the extensions from cFileExtensions
+INTERNAL FUNCTION __VfpLocFileSearch(cFileName AS STRING, cFileExtensions AS STRING) AS STRING
+    IF String.IsNullOrEmpty(cFileName)
+        RETURN ""
+    ENDIF
+    IF File(cFileName)
+        RETURN FPathName()
+    ENDIF
+    IF String.IsNullOrEmpty(System.IO.Path.GetExtension(cFileName))
+        FOREACH cExt AS STRING IN __VfpExtractExtensions(cFileExtensions)
+            IF File(cFileName + "." + cExt)
+                RETURN FPathName()
+            ENDIF
+        NEXT
+    ENDIF
+    RETURN ""
+END FUNCTION
+
+// Extracts "bare" extensions from the format "Desc:ext;Desc:ext,ext2" (without descriptions or wildcards)
+INTERNAL FUNCTION __VfpExtractExtensions(cFileExtensions AS STRING) AS List<STRING>
+    VAR aResult := List<STRING>{}
+    IF String.IsNullOrEmpty(cFileExtensions)
+        RETURN aResult
+    ENDIF
+    FOREACH cGroup AS STRING IN cFileExtensions:Split(<CHAR>{c';'})
+        VAR cExts  := cGroup
+        VAR nColon := cGroup:IndexOf(":")
+        IF nColon >= 0
+            cExts := cGroup:Substring(nColon + 1)
+        ENDIF
+        FOREACH cRaw AS STRING IN cExts:Split(<CHAR>{c','})
+            VAR cE := cRaw:Trim()
+            IF cE:Length > 0 .AND. cE:IndexOfAny(<CHAR>{c'*', c'?'}) < 0
+                aResult:Add(cE)
+            ENDIF
+        NEXT
+    NEXT
+    RETURN aResult
+END FUNCTION
+
+/// <include file="VFPDocs.xml" path="Runtimefunctions/inputbox/*" />
+[FoxProFunction("INPUTBOX", FoxFunctionCategory.UIAndWindow, FoxEngine.UI, FoxFunctionStatus.Full, FoxCriticality.High)];
+FUNCTION InputBox(cInputPrompt := "" AS STRING, cDialogCaption := "" AS STRING, cDefaultValue := "" AS STRING, ;
+                  nTimeout := 0 AS LONG, cTimeoutValue := "" AS STRING, cCancelValue := "" AS STRING) AS STRING
+    RETURN VfpUIService.Provider:InputBox(cInputPrompt, cDialogCaption, cDefaultValue, nTimeout, cTimeoutValue, cCancelValue)
 END FUNCTION

--- a/src/Runtime/XSharp.VFP/UI/VfpUIService.prg
+++ b/src/Runtime/XSharp.VFP/UI/VfpUIService.prg
@@ -18,11 +18,14 @@ BEGIN NAMESPACE XSharp.VFP
         METHOD GetColor(nDefaultColorNumber AS USUAL) AS INT
         METHOD GetFont(cFontName AS USUAL, nFontSize AS USUAL, cFontStyle AS USUAL, nFontCharSet AS USUAL) AS STRING
         METHOD GetPrinters(nValue AS INT) AS ARRAY
+        METHOD GetPrinter() AS STRING
         METHOD GetDir(cDirectory AS STRING, cText AS STRING, cCaption AS STRING, nFlags AS LONG, lRootOnly AS LOGIC) AS STRING
         METHOD GetFile(cFileExtensions AS STRING, cText AS STRING, cOpenButtonCaption AS STRING, nButtonType AS LONG, cTitleBarCaption AS STRING) AS STRING
         METHOD GetPict(cFileExtensions AS STRING, cFileNameCaption AS STRING, cOpenButtonCaption AS STRING) AS STRING
+        METHOD PutFile(cCustomText AS STRING, cFileName AS STRING, cFileExtensions AS STRING) AS STRING
         METHOD LoadPicture(cFileName AS STRING) AS OBJECT
         METHOD FontMetric(nAttribute AS LONG, cFontName AS USUAL, nFontSize AS USUAL, cFontStyle AS USUAL) AS LONG
+        METHOD InputBox(cInputPrompt AS STRING, cDialogCaption AS STRING, cDefaultValue AS STRING, nTimeout AS LONG, cTimeoutValue AS STRING, cCancelValue AS STRING) AS STRING
     END INTERFACE
 
     PUBLIC STATIC CLASS VfpUIService
@@ -139,6 +142,10 @@ BEGIN NAMESPACE XSharp.VFP
             RETURN {}
         END METHOD
 
+        PUBLIC METHOD GetPrinter() AS STRING
+            RETURN ""
+        END METHOD
+
         METHOD GetDir(cDirectory AS STRING, cText AS STRING, cCaption AS STRING, nFlags AS LONG, lRootOnly AS LOGIC) AS STRING
             RETURN ""
         END METHOD
@@ -151,6 +158,10 @@ BEGIN NAMESPACE XSharp.VFP
             RETURN ""
         END METHOD
 
+        METHOD PutFile(cCustomText AS STRING, cFileName AS STRING, cFileExtensions AS STRING) AS STRING
+            RETURN ""
+        END METHOD
+
         METHOD LoadPicture(cFileName AS STRING) AS OBJECT
             Console.WriteLine("LOADPICTURE: Attempted to load: " + cFileName)
             RETURN NULL_OBJECT
@@ -160,6 +171,9 @@ BEGIN NAMESPACE XSharp.VFP
             RETURN 0
         END METHOD
 
+        METHOD InputBox(cInputPrompt AS STRING, cDialogCaption AS STRING, cDefaultValue AS STRING, nTimeout AS LONG, cTimeoutValue AS STRING, cCancelValue AS STRING) AS STRING
+            RETURN cCancelValue
+        END METHOD
     END CLASS
 
 END NAMESPACE


### PR DESCRIPTION
Implements `GETPRINTER()`, `PUTFILE()`, `LOCFILE()`, `INPUTBOX()`. `INPUTBOX()` uses a new modal WinForms form (prompt + text entry + OK/Cancel) with optional timeout.