### PR TITLE
Implement NEWOBJECT() for basic cases

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/CommandTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/CommandTests.prg
@@ -393,6 +393,24 @@ BEGIN NAMESPACE XSharp.VFP.Tests
             RELEASE WINDOWS
             Assert.True(TRUE)
         END METHOD
+
+        [Fact, Trait("Category", "NewObject")];
+        METHOD NewObjectBasicTest AS VOID
+            VAR o := NEWOBJECT("Custom")
+            Assert.NotNull(o)
+            Assert.True(o IS Custom)
+        END METHOD
+
+        [Fact, Trait("Category", "NewObject")];
+        METHOD NewObjectWithEmptyModuleTest AS VOID
+            VAR o := NEWOBJECT("Custom", "")
+            Assert.NotNull(o)
+        END METHOD
+
+        [Fact, Trait("Category", "NewObject")];
+        METHOD NewObjectWithModuleThrows AS VOID
+            Assert.Throws<NotImplementedException>({ => NEWOBJECT("Custom", "algo.vcx") })
+        END METHOD
     END CLASS
 
 END NAMESPACE

--- a/src/Runtime/XSharp.VFP/Functions.prg
+++ b/src/Runtime/XSharp.VFP/Functions.prg
@@ -13,6 +13,42 @@ FUNCTION CreateObject(cClassName, _args ) AS OBJECT CLIPPER
     // The pseudo function _ARGS() returns the Clipper arguments array
     RETURN CreateInstance(_ARGS())
 
+/// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/newobject/*" />
+[FoxProFunction("NEWOBJECT", FoxFunctionCategory.ClassAndObject, FoxEngine.LanguageCore, FoxFunctionStatus.Partial, FoxCriticality.High)];
+FUNCTION NewObject(cClassName, _args) AS OBJECT CLIPPER
+    VAR nCount := PCount()
+
+    IF nCount >= 2
+        VAR uModule := _GetFParam(2)
+        IF IsString(uModule) .AND. !Empty(uModule)
+            THROW NotImplementedException{"NEWOBJECT with cModule (.vcx/.app) is not supported"}
+        ENDIF
+    ENDIF
+
+    IF nCount >= 3
+        VAR uApp := _GetFParam(3)
+        IF IsString(uApp) .AND. !Empty(uApp)
+            THROW NotImplementedException{"NEWOBJECT with cInApplication (.vcx/.app) is not supported"}
+        ENDIF
+    ENDIF
+
+    // Init params start after cClassName, skipping cModule/cInApp if present
+    VAR nInitStart := IIF(nCount >= 3, 4, IIF(nCount >= 2, 3, 2))
+    VAR nInitCount := nCount - nInitStart + 1
+
+    IF nInitCount <= 0
+        RETURN CreateInstance(cClassName)
+    ENDIF
+
+    VAR uArgs := USUAL[]{nInitCount + 1}
+    uArgs[0] := cClassName
+    FOR VAR i := 1 TO nInitCount
+        uArgs[i] := _GetFParam(nInitStart + i - 1)
+    NEXT
+
+    RETURN CreateInstance(uArgs)
+END FUNCTION
+
 /// <include file="VfpRuntimeDocs.xml" path="Runtimefunctions/createobjectex/*" />
 [FoxProFunction("CREATEOBJECTEX", FoxFunctionCategory.ClassAndObject, FoxEngine.Interop, FoxFunctionStatus.Full, FoxCriticality.High)];
 FUNCTION CreateObjectEx(cClsIdOrcProgId, cComputerName , cIID ) AS OBJECT CLIPPER

--- a/src/Runtime/XSharp.VFP/ToDo-NOP.prg
+++ b/src/Runtime/XSharp.VFP/ToDo-NOP.prg
@@ -8,13 +8,6 @@
 #pragma options("vo15", on)
 
 /// <summary>-- todo --</summary>
-/// <include file="VFPDocs.xml" path="Runtimefunctions/newobject/*" />
-[FoxProFunction("NEWOBJECT", FoxFunctionCategory.ClassAndObject, FoxEngine.LanguageCore, FoxFunctionStatus.Stub, FoxCriticality.High)];
-FUNCTION NewObject( cClassName ,_args) AS OBJECT
-    THROW NotImplementedException{}
-    // RETURN NULL_OBJECT
-
-/// <summary>-- todo --</summary>
 /// <include file="VFPDocs.xml" path="Runtimefunctions/oldval/*" />
 [FoxProFunction("OLDVAL", FoxFunctionCategory.CursorAndTable, FoxEngine.WorkArea, FoxFunctionStatus.Stub, FoxCriticality.High)];
 FUNCTION OldVal( cExpression , uArea ) AS USUAL


### PR DESCRIPTION
Implements the basic case of `NEWOBJECT()` where `cModule` and `cInApplication` are empty or omitted, delegating to `CreateInstance()`, identical behavior to `CREATEOBJECT()`. When `cModule` or `cInApplication` are specified (non-empty), throws `NotImplementedException` since loading classes from external .vcx/.app files is not supported in X#.