### PR TITLE
Fix VFP CAST() to accept full type names

### DIFF
--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -710,12 +710,12 @@
 #command RD <(dir)>    => _cmdDirRemove (<(dir)>)
 #command RMDIR <(dir)> => _cmdDirRemove (<(dir)>)
 
-// CAST AS Expression
-// types in the order of the FoxPro docs!
-
-#translate CAST ( <expression> AS <type:W,C,Y,D,T,B,F,G,I,L,M,N,Q,V>)                   => __FoxCast(<expression>,<(type)>, -1, -1)
-#translate CAST ( <expression> AS <type:W,C,Y,D,T,B,F,G,I,L,M,N,Q,V>(<width> ) )        => __FoxCast(<expression>,<(type)>, <width>,-1)
-#translate CAST ( <expression> AS <type:W,C,Y,D,T,B,F,G,I,L,M,N,Q,V>(<width> ,<dec>) )  => __FoxCast(<expression>,<(type)>, <width>,<dec>)
+// CAST AS Expression  -->  CAST( eExpr AS cType [(nWidth[,nPrec])] [NULL | NOT NULL] )
+// cType: single-letter code, full type name, or a parenthesized expression that yields the type
+#translate CAST ( <expression> AS <type:W,BLOB,C,CHAR,CHARACTER,Y,CURRENCY,D,DATE,T,DATETIME,B,DOUBLE,F,FLOAT,G,GENERAL,I,INT,INTEGER,L,LOGICAL,M,MEMO,N,NUM,NUMERIC,Q,VARBINARY,V,VARCHAR> ( <width> , <dec> ) [NOT] [NULL] )  => __FoxCast( <expression>, <(type)>, <width>, <dec> )
+#translate CAST ( <expression> AS <type:W,BLOB,C,CHAR,CHARACTER,Y,CURRENCY,D,DATE,T,DATETIME,B,DOUBLE,F,FLOAT,G,GENERAL,I,INT,INTEGER,L,LOGICAL,M,MEMO,N,NUM,NUMERIC,Q,VARBINARY,V,VARCHAR> ( <width> ) [NOT] [NULL] )         => __FoxCast( <expression>, <(type)>, <width>, -1 )
+#translate CAST ( <expression> AS <type:W,BLOB,C,CHAR,CHARACTER,Y,CURRENCY,D,DATE,T,DATETIME,B,DOUBLE,F,FLOAT,G,GENERAL,I,INT,INTEGER,L,LOGICAL,M,MEMO,N,NUM,NUMERIC,Q,VARBINARY,V,VARCHAR> [NOT] [NULL] )                       => __FoxCast( <expression>, <(type)>, -1, -1 )
+#translate CAST ( <expression> AS ( <typeExpr> ) [NOT] [NULL] )                                                                                                                                                              => __FoxCast( <expression>, <typeExpr>, -1, -1 )
 
 #command LABEL <*any*> => __VfpUnsupported(<"udc">)
 

--- a/src/Runtime/XSharp.VFP.Tests/CastTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/CastTests.prg
@@ -1,0 +1,68 @@
+﻿//
+// Copyright (c) XSharp B.V.  All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+// See License.txt in the project root for license information.
+//
+USING System
+USING XUnit
+
+BEGIN NAMESPACE XSharp.VFP.Tests
+
+    CLASS CastTests
+        STATIC CONSTRUCTOR
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+
+        // Full type names must route to the same handler as the single-letter codes
+        [Fact, Trait("Category", "Cast")];
+        METHOD Cast_FullTypeNames() AS VOID
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+            Assert.Equal("N", VarType(CAST("123" AS Integer)))
+            Assert.Equal("N", VarType(CAST("123" AS Int)))
+            Assert.Equal("N", VarType(CAST("123" AS Num)))       // Num alias
+            Assert.Equal("N", VarType(CAST("123" AS Numeric)))
+            Assert.Equal("C", VarType(CAST(65 AS Character)))
+            Assert.Equal("C", VarType(CAST(65 AS Char)))
+            Assert.Equal("Y", VarType(CAST(1 AS Currency)))
+            Assert.Equal("L", VarType(CAST(1 AS Logical)))
+
+        // Type name is case-insensitive
+        [Fact, Trait("Category", "Cast")];
+        METHOD Cast_CaseInsensitive() AS VOID
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+            Assert.Equal("N", VarType(CAST("123" AS n)))
+            Assert.Equal("N", VarType(CAST("123" AS integer)))
+
+        // numeric -> character: default width is 1 (VFP), explicit width honored
+        [Fact, Trait("Category", "Cast")];
+        METHOD Cast_CharacterWidth() AS VOID
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+            Assert.Equal("6", (STRING) CAST(65 AS C))            // "65" truncated to default width 1
+            Assert.True(Len(CAST(65 AS C)) == 1)
+            Assert.True(Len(CAST(65 AS C(20))) == 20)
+            Assert.Equal("65", AllTrim(CAST(65 AS C(20))))
+
+        // width + precision
+        [Fact, Trait("Category", "Cast")];
+        METHOD Cast_NumericPrecision() AS VOID
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+            Assert.Equal("N", VarType(CAST(3.14159 AS Numeric(8,2))))
+
+        // NULL / NOT NULL clause must be accepted (and ignored at expression level)
+        [Fact, Trait("Category", "Cast")];
+        METHOD Cast_NullClause() AS VOID
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+            Assert.Equal("N", VarType(CAST("123" AS Integer NULL)))
+            Assert.Equal("N", VarType(CAST("123" AS Integer NOT NULL)))
+            Assert.Equal("C", VarType(CAST(65 AS Char(10) NOT NULL)))
+
+        // dynamic type: CAST(x AS (expr)) where expr yields the type name at runtime
+        [Fact, Trait("Category", "Cast")];
+        METHOD Cast_DynamicType() AS VOID
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+            LOCAL cTipo := "N" AS STRING
+            Assert.Equal("N", VarType(CAST(65 AS (cTipo))))
+            Assert.Equal("N", VarType(CAST(65 AS (cTipo) NOT NULL)))
+
+    END CLASS
+
+END NAMESPACE

--- a/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
+++ b/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
@@ -93,6 +93,7 @@
   <ItemGroup>
     <Compile Include="AMembersTests.prg" />
     <Compile Include="AUsedTests.prg" />
+    <Compile Include="CastTests.prg" />
     <Compile Include="CommandTests.prg" />
     <Compile Include="CompObjTests.prg" />
     <Compile Include="CopyToTests.prg" />

--- a/src/Runtime/XSharp.VFP/MiscFunctions.prg
+++ b/src/Runtime/XSharp.VFP/MiscFunctions.prg
@@ -35,16 +35,16 @@ FUNCTION EVL( eExpression1 AS USUAL, eExpression2  AS USUAL) AS USUAL
     ENDIF
     RETURN eExpression2
 
-//#translate CAST ( <expression> AS <type:W,C,Y,D,T,B,F,G,I,L,M,N,Q,V>)                   => __FoxCast(<expression>,<(type)>)
-//#translate CAST ( <expression> AS <type:W,C,Y,D,T,B,F,G,I,L,M,N,Q,V>(<width> ) )        => __FoxCast(<expression>,<(type)>, <width>,-1)
-//#translate CAST ( <expression> AS <type:W,C,Y,D,T,B,F,G,I,L,M,N,Q,V>(<width> ,<dec>) )  => __FoxCast(<expression>,<(type)>, <width>,<dec>)
-
 FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LONG) AS USUAL
     LOCAL result := NIL AS USUAL
     LOCAL error := FALSE AS LOGIC
-    // This follows the FoxPro conversion rules from the CAST() function as close as possible
+
+    // VFP accepts full type names (and Num) besides single-letter codes, and is case-insensitive
+    targetType := Upper(targetType)
+
     SWITCH targetType
     CASE "W" // blob
+    CASE "BLOB"
         // no width
         // no decimals
         IF IsBinary(expr)
@@ -55,9 +55,13 @@ FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LO
             error := TRUE
         ENDIF
     CASE "C" // Char
-        // no decimals
-        result := PadR(expr,10)
+    CASE "CHAR"
+    CASE "CHARACTER"
+        // width applies, decimals disregarded; VFP default width is 1
+        VAR str := ((OBJECT)expr):ToString()
+        result := PadR(str, IIF(nLen == -1, 1, nLen))
     CASE "Y" // Currency
+    CASE "CURRENCY"
         // no width
         // no decimals
         IF IsNumeric(expr)
@@ -66,6 +70,7 @@ FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LO
             error := TRUE
         ENDIF
     CASE "D" // Date
+    CASE "DATE"
         // no width
         // no decimals
         IF IsString(expr)
@@ -76,6 +81,7 @@ FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LO
             error := TRUE
         ENDIF
     CASE "T" // DateTime
+    CASE "DATETIME"
         // no width
         // no decimals
         IF IsString(expr)
@@ -86,6 +92,7 @@ FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LO
             error := TRUE
         ENDIF
     CASE "B" // Double
+    CASE "DOUBLE"
         // nLen is # of decimals
         IF IsString(expr)
             expr := Val(expr)
@@ -99,7 +106,10 @@ FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LO
             error := TRUE
         ENDIF
     CASE "N" // Numeric
+    CASE "NUM"
+    CASE "NUMERIC"
     CASE "F" // Float
+    CASE "FLOAT"
         IF IsString(expr)
             expr := Val(expr)
         ENDIF
@@ -112,10 +122,13 @@ FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LO
             error := TRUE
         ENDIF
     CASE "G" // General
+    CASE "GENERAL"
         // no width
         // no decimals
         result := expr
     CASE "I" // Int
+    CASE "INT"
+    CASE "INTEGER"
         // no width
         // no decimals
         IF IsString(expr)
@@ -125,6 +138,7 @@ FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LO
             result := (INT) expr
         ENDIF
     CASE "L" // Logic
+    CASE "LOGICAL"
         // no width
         // no decimals
         IF IsString(expr)
@@ -144,10 +158,12 @@ FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LO
             error := TRUE
         ENDIF
     CASE "M" // Memo
+    CASE "MEMO"
         // no width
         // no decimals
         result := ((OBJECT)expr):ToString()
     CASE "Q" // VarBinary
+    CASE "VARBINARY"
         // no decimals
         IF IsString(expr)
             expr := BINARY{expr}
@@ -168,6 +184,7 @@ FUNCTION __FoxCast(expr AS USUAL, targetType AS STRING, nLen AS LONG, nDec AS LO
             error := TRUE
         ENDIF
     CASE "V" // VarChar
+    CASE "VARCHAR"
         // no decimals
         VAR str := ((OBJECT)expr):ToString()
         IF nLen != -1 .AND. nLen < str:Length


### PR DESCRIPTION
In the [Visual FoxPro CAST() Function](https://www.yaldex.com/fox_pro_tutorial/html/55c599e9-18d1-4ac6-b311-e6677dc3b0b7.htm) also works with full type names but I saw we're allowing single-letter type codes (`N`, `C`, `I`, ...).

## Changes
- `FoxProCmd.xh`: The `CAST` translate rules now cover the full VFP spec.
- `MiscFunctions.prg`: 
     - upper-cases the target type so matching in case-insensitive.
     - accepts the full type name aliases of the letter codes.
     - fixes the `Character` conversion, which ignored the requested width.
