### PR TITLE
Fix SET SECONDS and COPY MEMO commands

### DIFF
--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -227,8 +227,11 @@
 // This variant moves the ALL clause to the end. This is needed because the WITH clause is declared as non optional
 #command REPLACE <*clauses*> ALL <*moreclauses*> => REPLACE <clauses> <moreclauses> ALL
 
-#command COPY MEMO <field> TO <(file)> <add:ADDITIVE> [AS <nCP>]  ;
-        => DbCopyMemo( <"field">, <(file)>, <ADD>[, <nCP>] )
+#command COPY MEMO <field> TO <(file)> [<add:ADDITIVE>]           ;
+        => DbCopyMemo( <"field">, <(file)>, <.add.>, 0 )
+
+#command COPY MEMO <field> TO <(file)> [<add:ADDITIVE>] AS <nCP>  ;
+        => DbCopyMemo( <"field">, <(file)>, <.add.>, <nCP> )
 
 // Scoped REPLACE — without IN clause
 // Note: no nested optional ADDITIVE inside the repeated clause: the preprocessor

--- a/src/Common/FoxProSet.xh
+++ b/src/Common/FoxProSet.xh
@@ -80,7 +80,7 @@
 #command SET HOURS TO 12                  => SetHours(12)
 #command SET HOURS TO 24                  => SetHours(24)
 
-#command SET SECONDS <x:ON,OFF,&>         => SetSeconds(<(x)>)
+#command SET SECONDS <x:ON,OFF,&>         => Set(Set.Seconds, <(x)>)
 
 ///////////////////////////////////////////////////////////////////////////////
 // SET commands for Numric formatting

--- a/src/Runtime/XSharp.VFP.Tests/UdcCommandFixTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/UdcCommandFixTests.prg
@@ -1,0 +1,79 @@
+﻿//
+// Copyright (c) XSharp B.V.  All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+// See License.txt in the project root for license information.
+//
+USING System
+USING System.IO
+USING XUnit
+
+BEGIN NAMESPACE XSharp.VFP.Tests
+
+    CLASS UdcCommandFixTests
+
+        STATIC CONSTRUCTOR
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+        END CONSTRUCTOR
+
+        PRIVATE METHOD TempFile() AS STRING
+            RETURN Path.Combine(Path.GetTempPath(), "CopyMemo_" + Guid.NewGuid():ToString("N") + ".txt")
+        END METHOD
+
+        PRIVATE METHOD CreateMemoCursor() AS VOID
+            CREATE CURSOR curmemo (m1 M)
+            APPEND BLANK
+            REPLACE m1 WITH "memo content"
+        END METHOD
+
+        // --- SET SECONDS (#2026) ---
+
+        [Fact, Trait("Category", "SetCommands")];
+        METHOD SetSecondsOnOffUpdatesTheSetting AS VOID
+            VAR lOld := SetSeconds()
+            TRY
+                SET SECONDS ON
+                Assert.True(SetSeconds())
+                SET SECONDS OFF
+                Assert.False(SetSeconds())
+            FINALLY
+                SetSeconds(lOld)
+            END TRY
+        END METHOD
+
+        // --- COPY MEMO (#2022) ---
+
+        [Fact, Trait("Category", "CopyMemo")];
+        METHOD CopyMemoWorksWithoutAdditive AS VOID
+            SELF:CreateMemoCursor()
+            VAR cFile := SELF:TempFile()
+            COPY MEMO m1 TO (cFile)
+            Assert.Equal("memo content", File.ReadAllText(cFile))
+            File.Delete(cFile)
+        END METHOD
+
+        [Fact, Trait("Category", "CopyMemo")];
+        METHOD CopyMemoAppendsWithAdditive AS VOID
+            SELF:CreateMemoCursor()
+            VAR cFile := SELF:TempFile()
+            COPY MEMO m1 TO (cFile)
+            COPY MEMO m1 TO (cFile) ADDITIVE
+            Assert.Equal("memo contentmemo content", File.ReadAllText(cFile))
+            File.Delete(cFile)
+        END METHOD
+
+        [Fact, Trait("Category", "CopyMemo")];
+        METHOD CopyMemoAcceptsTheAsCodePageClause AS VOID
+            SELF:CreateMemoCursor()
+            VAR cFile := SELF:TempFile()
+            COPY MEMO m1 TO (cFile) AS 1252
+            Assert.True(File.Exists(cFile))
+            File.Delete(cFile)
+            VAR cFile2 := SELF:TempFile()
+            COPY MEMO m1 TO (cFile2) ADDITIVE AS 1252
+            Assert.True(File.Exists(cFile2))
+            File.Delete(cFile2)
+        END METHOD
+
+    END CLASS
+
+END NAMESPACE

--- a/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
+++ b/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
@@ -115,6 +115,7 @@
     <Compile Include="OtherTests.prg" />
     <Compile Include="Properties\AssemblyInfo.prg" />
     <Compile Include="StringTests.prg" />
+    <Compile Include="UdcCommandFixTests.prg" />
     <Compile Include="VfpStringFunctionsTests.prg" />
     <Compile Include="WrappedStubsTests.prg" />
   </ItemGroup>


### PR DESCRIPTION
Two small fixes in UDC.

`SET SECONDS ON/OFF` #2026 and `COPY MEMO` required the `ADDITIVE` clause #2022 