### PR TITLE
Fix NEWOBJECT() with init parameters: XSharp.VFP uses 1 based arrays

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/CommandTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/CommandTests.prg
@@ -411,6 +411,42 @@ BEGIN NAMESPACE XSharp.VFP.Tests
         METHOD NewObjectWithModuleThrows AS VOID
             Assert.Throws<NotImplementedException>({ => NEWOBJECT("Custom", "algo.vcx") })
         END METHOD
+
+        [Fact, Trait("Category", "NewObject")];
+        METHOD NewObjectWithOneInitParameterTest AS VOID
+            VAR o := NEWOBJECT("NewObjectTestClass", "", "", 42)
+            Assert.NotNull(o)
+            VAR oTest := (NewObjectTestClass)o
+            Assert.Equal(42, oTest:Arg1)
+            Assert.Equal("", oTest:Arg2)
+        END METHOD
+
+        [Fact, Trait("Category", "NewObject")];
+        METHOD NewObjectWithInitParametersTest AS VOID
+            VAR o := NEWOBJECT("NewObjectTestClass", "", "", 42, "abc")
+            Assert.NotNull(o)
+            VAR oTest := (NewObjectTestClass)o
+            Assert.Equal(42, oTest:Arg1)
+            Assert.Equal("abc", oTest:Arg2)
+        END METHOD
     END CLASS
 
 END NAMESPACE
+
+CLASS NewObjectTestClass
+    PROPERTY Arg1 AS INT AUTO
+    PROPERTY Arg2 AS STRING AUTO
+
+    CONSTRUCTOR()
+        SELF:Arg1 := 0
+        SELF:Arg2 := ""
+
+    CONSTRUCTOR(nArg1 AS INT)
+        SELF:Arg1 := nArg1
+        SELF:Arg2 := ""
+
+    CONSTRUCTOR(nArg1 AS INT, cArg2 AS STRING)
+        SELF:Arg1 := nArg1
+        SELF:Arg2 := cArg2
+
+END CLASS

--- a/src/Runtime/XSharp.VFP/Functions.prg
+++ b/src/Runtime/XSharp.VFP/Functions.prg
@@ -41,9 +41,9 @@ FUNCTION NewObject(cClassName, cModule, cInApplication, eParameter1, eParameter2
     // NOTE: this project is compiled with 1-based array, so uArgs[1] is the
     //       first element.
     VAR uArgs := USUAL[]{nInitCount + 1}
-    uArgs[1] := cClassName
+    uArgs[__ARRAYBASE__] := cClassName
     FOR VAR i := 1 TO nInitCount
-        uArgs[i + 1] := _GetFParam(nInitStart + i - 1)
+        uArgs[__ARRAYBASE__ + i] := _GetFParam(nInitStart + i - 1)
     NEXT
 
     RETURN CreateInstance(uArgs)

--- a/src/Runtime/XSharp.VFP/Functions.prg
+++ b/src/Runtime/XSharp.VFP/Functions.prg
@@ -38,10 +38,12 @@ FUNCTION NewObject(cClassName, cModule, cInApplication, eParameter1, eParameter2
         RETURN CreateInstance(cClassName)
     ENDIF
 
+    // NOTE: this project is compiled with 1-based array, so uArgs[1] is the
+    //       first element.
     VAR uArgs := USUAL[]{nInitCount + 1}
-    uArgs[0] := cClassName
+    uArgs[1] := cClassName
     FOR VAR i := 1 TO nInitCount
-        uArgs[i] := _GetFParam(nInitStart + i - 1)
+        uArgs[i + 1] := _GetFParam(nInitStart + i - 1)
     NEXT
 
     RETURN CreateInstance(uArgs)


### PR DESCRIPTION
Fix in `Functions.prg`. Use 1 based  indexes. I added a comment so the next person copying code from `XSharp.RT` does not repeat it.