### PR TITLE
[Vsintegration] Show "Add Assembly/Project Reference" for SDK projects

### DIFF
--- a/src/VisualStudio/ProjectBase/VsCommands.cs
+++ b/src/VisualStudio/ProjectBase/VsCommands.cs
@@ -102,5 +102,17 @@ namespace Microsoft.VisualStudio.Project
 
         public const int IDM_VS_CTXT_PACKAGEREFERENCE = 1187;
         public const int IDM_VS_CTXT_PACKAGEREFERENCE_GROUP = 1186;
+
+        // Context menus of the "Dependencies" tree of SDK style projects.
+        // These menus contain the "Add Assembly Reference..." and "Add Project Reference..."
+        // commands from the guidVSStd16 command set.
+        [SuppressMessage("Microsoft.Naming", "CA1707:IdentifiersShouldNotContainUnderscores")]
+        public const int IDM_VS_CTXT_DEPENDENCYTARGET = 0x04A0;
+
+        [SuppressMessage("Microsoft.Naming", "CA1707:IdentifiersShouldNotContainUnderscores")]
+        public const int IDM_VS_CTXT_REFERENCE_GROUP = 0x04A1;
+
+        [SuppressMessage("Microsoft.Naming", "CA1707:IdentifiersShouldNotContainUnderscores")]
+        public const int IDM_VS_CTXT_PROJECTREFERENCE_GROUP = 0x04A6;
     }
 }

--- a/src/VisualStudio/ProjectPackage/NodesSDK/SdkDependenciesContainer.cs
+++ b/src/VisualStudio/ProjectPackage/NodesSDK/SdkDependenciesContainer.cs
@@ -97,6 +97,36 @@ namespace XSharp.Project
             base.RemoveChild(node);
         }
 
+        /// <summary>
+        /// Handle the guidVSStd16 "Add ... Reference..." commands of the IDM_VS_CTXT_REFERENCEROOT menu.
+        /// </summary>
+        /// <remarks>
+        /// ReferenceContainerNode.QueryStatusOnNode returns OLECMDERR_E_UNKNOWNGROUP for every command
+        /// group other than the 97 and 2K sets without calling its base, so we have to answer the
+        /// guidVSStd16 commands here, before base is called.
+        /// </remarks>
+        protected override int QueryStatusOnNode(System.Guid cmdGroup, uint cmd, System.IntPtr pCmdText, ref QueryStatusResult result)
+        {
+            if (cmdGroup == XSharpSdkProjectNode.VsStd16 && this.ProjectMgr is XSharpSdkProjectNode sdk)
+            {
+                var hr = sdk.QueryStatusReferenceCommand(cmd, ref result);
+                if (hr == Microsoft.VisualStudio.VSConstants.S_OK)
+                    return hr;
+            }
+            return base.QueryStatusOnNode(cmdGroup, cmd, pCmdText, ref result);
+        }
+
+        protected override int ExecCommandOnNode(System.Guid cmdGroup, uint cmd, uint nCmdexecopt, System.IntPtr pvaIn, System.IntPtr pvaOut)
+        {
+            if (cmdGroup == XSharpSdkProjectNode.VsStd16 && this.ProjectMgr is XSharpSdkProjectNode sdk)
+            {
+                var hr = sdk.ExecReferenceCommand(cmd);
+                if (hr != Microsoft.VisualStudio.VSConstants.E_NOTIMPL)
+                    return hr;
+            }
+            return base.ExecCommandOnNode(cmdGroup, cmd, nCmdexecopt, pvaIn, pvaOut);
+        }
+
         public void DeleteDependencies(string targetframework)
         {
 

--- a/src/VisualStudio/ProjectPackage/NodesSDK/SdkFolderNodes.cs
+++ b/src/VisualStudio/ProjectPackage/NodesSDK/SdkFolderNodes.cs
@@ -39,6 +39,38 @@ namespace XSharp.Project
         {
             return VSConstants.S_FALSE;
         }
+
+        /// <summary>
+        /// Handle the guidVSStd16 "Add ... Reference..." commands for the nodes inside the
+        /// "Dependencies" tree that expose one of the reference group context menus.
+        /// </summary>
+        /// <remarks>
+        /// FolderNode.QueryStatusOnNode returns OLECMDERR_E_UNKNOWNGROUP for every command group
+        /// other than the 97 and 2K sets without calling its base, so this has to happen before
+        /// base is called. Which of the commands actually shows up is decided by the menu that
+        /// <see cref="MenuCommandId"/> returns.
+        /// </remarks>
+        protected override int QueryStatusOnNode(Guid cmdGroup, uint cmd, IntPtr pCmdText, ref QueryStatusResult result)
+        {
+            if (cmdGroup == XSharpSdkProjectNode.VsStd16 && this.ProjectMgr is XSharpSdkProjectNode sdk)
+            {
+                var hr = sdk.QueryStatusReferenceCommand(cmd, ref result);
+                if (hr == VSConstants.S_OK)
+                    return hr;
+            }
+            return base.QueryStatusOnNode(cmdGroup, cmd, pCmdText, ref result);
+        }
+
+        protected override int ExecCommandOnNode(Guid cmdGroup, uint cmd, uint cmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
+        {
+            if (cmdGroup == XSharpSdkProjectNode.VsStd16 && this.ProjectMgr is XSharpSdkProjectNode sdk)
+            {
+                var hr = sdk.ExecReferenceCommand(cmd);
+                if (hr != VSConstants.E_NOTIMPL)
+                    return hr;
+            }
+            return base.ExecCommandOnNode(cmdGroup, cmd, cmdexecopt, pvaIn, pvaOut);
+        }
     }
     class XSharpSdkProjectsNode : XSharpSdkFolderNode
     {
@@ -47,6 +79,9 @@ namespace XSharp.Project
         {
         }
         public override int SortPriority => DefaultSortOrderNode.ProjectsNode;
+
+        // The "Projects" group menu of the dependencies tree. Carries "Add Project Reference...".
+        public override int MenuCommandId => VsMenus.IDM_VS_CTXT_PROJECTREFERENCE_GROUP;
     }
     class XSharpSdkAssembliesNode : XSharpSdkFolderNode
     {
@@ -55,6 +90,9 @@ namespace XSharp.Project
         {
         }
         public override int SortPriority => DefaultSortOrderNode.AssembliesNode;
+
+        // The "Assemblies" group menu of the dependencies tree. Carries "Add Assembly Reference...".
+        public override int MenuCommandId => VsMenus.IDM_VS_CTXT_REFERENCE_GROUP;
     }
     [DebuggerDisplay("Frameworks {Parent?.Caption,nq}")]
     class XSharpSdkFrameworksNode : XSharpSdkFolderNode

--- a/src/VisualStudio/ProjectPackage/NodesSDK/SdkProjectNode.cs
+++ b/src/VisualStudio/ProjectPackage/NodesSDK/SdkProjectNode.cs
@@ -17,6 +17,7 @@ using System.Linq;
 
 using VsCommands = Microsoft.VisualStudio.VSConstants.VSStd97CmdID;
 using VsCommands2K = Microsoft.VisualStudio.VSConstants.VSStd2KCmdID;
+using OleConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
 
 using XSharpModel;
 
@@ -443,12 +444,68 @@ namespace XSharp.Project
         }
 
 
-        protected Guid VsStd16 = new Guid("8F380902-6040-4097-9837-D3F40E66F908");
-        protected const uint idAddAssemblyReference = (uint) VSConstants.VSStd16CmdID.AddAssemblyReference;
-        protected const uint idAddCOMReference = (uint)VSConstants.VSStd16CmdID.AddComReference;
-        protected const uint idAddProjectReference = (uint)VSConstants.VSStd16CmdID.AddProjectReference;
-        protected const uint idAddSharedProjectReference = (uint)VSConstants.VSStd16CmdID.AddSharedProjectReference;
-        protected const uint idAddSDKReference = (uint)VSConstants.VSStd16CmdID.AddSdkReference;
+        internal static readonly Guid VsStd16 = new Guid("8F380902-6040-4097-9837-D3F40E66F908");
+        internal const uint idAddAssemblyReference = (uint) VSConstants.VSStd16CmdID.AddAssemblyReference;
+        internal const uint idAddCOMReference = (uint)VSConstants.VSStd16CmdID.AddComReference;
+        internal const uint idAddProjectReference = (uint)VSConstants.VSStd16CmdID.AddProjectReference;
+        internal const uint idAddSharedProjectReference = (uint)VSConstants.VSStd16CmdID.AddSharedProjectReference;
+        internal const uint idAddSDKReference = (uint)VSConstants.VSStd16CmdID.AddSdkReference;
+
+        /// <summary>
+        /// Answer the "Add ... Reference..." commands of the guidVSStd16 command set.
+        /// </summary>
+        /// <remarks>
+        /// These commands are DefaultInvisible + DynamicVisibility, so they only appear when we
+        /// report them as SUPPORTED. VS asks the _selected_ node, so the nodes inside the
+        /// "Dependencies" tree have to delegate here, otherwise the commands stay hidden.
+        /// </remarks>
+        internal int QueryStatusReferenceCommand(uint cmd, ref QueryStatusResult result)
+        {
+            switch (cmd)
+            {
+                case idAddProjectReference:
+                    result |= QueryStatusResult.SUPPORTED | QueryStatusResult.ENABLED;
+                    return VSConstants.S_OK;
+
+                case idAddAssemblyReference:
+                case idAddCOMReference:
+                    if (this.IsNetCoreApp)
+                    {
+                        result |= QueryStatusResult.NOTSUPPORTED | QueryStatusResult.INVISIBLE;
+                    }
+                    else
+                    {
+                        result |= QueryStatusResult.SUPPORTED | QueryStatusResult.ENABLED;
+                    }
+                    return VSConstants.S_OK;
+
+                case idAddSharedProjectReference:
+                case idAddSDKReference:
+                    result |= QueryStatusResult.NOTSUPPORTED | QueryStatusResult.INVISIBLE;
+                    return VSConstants.S_OK;
+            }
+            return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
+        }
+
+        /// <summary>
+        /// Execute one of the guidVSStd16 "Add ... Reference..." commands.
+        /// Returns E_NOTIMPL when the command is not one of ours, so the caller can call its base.
+        /// </summary>
+        internal int ExecReferenceCommand(uint cmd)
+        {
+            switch (cmd)
+            {
+                case idAddProjectReference:
+                    return this.AddProjectReference();
+
+                case idAddAssemblyReference when !this.IsNetCoreApp:
+                    return this.AddAssemblyReference();
+
+                case idAddCOMReference when !this.IsNetCoreApp:
+                    return this.AddCOMReference();
+            }
+            return VSConstants.E_NOTIMPL;
+        }
 
 
         protected override QueryStatusResult QueryStatusCommandFromOleCommandTarget(Guid cmdGroup, uint cmd, out bool handled)
@@ -479,29 +536,9 @@ namespace XSharp.Project
             }
             else if (cmdGroup == VsStd16)
             {
-                switch (cmd)
-                {
-                    case idAddProjectReference:
-                        result |= QueryStatusResult.SUPPORTED | QueryStatusResult.ENABLED;
-                        return VSConstants.S_OK;
-
-                    case idAddAssemblyReference:
-                    case idAddCOMReference:
-                        if (this.IsNetCoreApp)
-                        {
-                            result |= QueryStatusResult.NOTSUPPORTED | QueryStatusResult.INVISIBLE;
-                        }
-                        else
-                        {
-                            result |= QueryStatusResult.SUPPORTED | QueryStatusResult.ENABLED;
-                        }
-                        return VSConstants.S_OK;
-
-                    case idAddSharedProjectReference:
-                    case idAddSDKReference:
-                        result |= QueryStatusResult.NOTSUPPORTED | QueryStatusResult.INVISIBLE;
-                        return VSConstants.S_OK;
-                }
+                var hr = QueryStatusReferenceCommand(cmd, ref result);
+                if (hr == VSConstants.S_OK)
+                    return hr;
             }
             return base.QueryStatusOnNode(cmdGroup, cmd, pCmdText, ref result);
         }
@@ -510,18 +547,9 @@ namespace XSharp.Project
         {
             if (cmdGroup == VsStd16)
             {
-                switch (cmd)
-                {
-                    case idAddProjectReference:
-                        return this.AddProjectReference();
-
-                    case idAddAssemblyReference when  !this.IsNetCoreApp:
-                        return this.AddAssemblyReference();
-
-                    case idAddCOMReference when !this.IsNetCoreApp:
-                        return this.AddCOMReference();
-
-                }
+                var hr = ExecReferenceCommand(cmd);
+                if (hr != VSConstants.E_NOTIMPL)
+                    return hr;
             }
             return base.ExecCommandOnNode(cmdGroup, cmd, nCmdexecopt, pvaIn, pvaOut);
         }


### PR DESCRIPTION
### Problem
In SDK-style projects the "Add Assembly Reference..." and "Add Project Reference..."
menu items are missing everywhere in the Solution Explorer.

The `guidVSStd16` commands are declared `DefaultInvisible` + `DynamicVisibility` by the
shell, so they only appear when the selected node reports them as SUPPORTED. VS routes
`QueryStatus` to the *selected* node, not to the project node — and both
`ReferenceContainerNode.QueryStatusOnNode` and `FolderNode.QueryStatusOnNode` return
`OLECMDERR_E_UNKNOWNGROUP` for any command group other than the 97/2K sets *without
calling their base*. `QueryStatusSelectionOnNodes` breaks out on that negative HRESULT,
so the commands stayed hidden throughout the "Dependencies" tree. The handling that
already existed in `XSharpSdkProjectNode` was only reachable when the project node
itself was selected.

Additionally, the "Projects" and "Assemblies" nodes returned `IDM_VS_CTXT_NOCOMMANDS`,
so right-clicking them showed an empty menu. And since the legacy "Add Reference..."
(`guidVSStd2K ADDREFERENCE`) is deliberately hidden for SDK projects, nothing was left
to click.

### Changes
- Extract the VsStd16 handling from `XSharpSdkProjectNode` into
  `QueryStatusReferenceCommand()` / `ExecReferenceCommand()` so the nodes of the
  dependencies tree can delegate to it. Behaviour is unchanged, including hiding
  assembly and COM references for `.NetCore` / `.NetStandard` targets.
- Answer the VsStd16 commands in `XSharpDependenciesContainerNode` and in
  `XSharpSdkFolderNode`, before base is called.
- Give the "Projects" and "Assemblies" nodes their real context menus
  (`IDM_VS_CTXT_PROJECTREFERENCE_GROUP` / `IDM_VS_CTXT_REFERENCE_GROUP`).
  Copy/cut/delete/rename remain suppressed via `XFolderNode`.
- Add the missing dependencies tree menu ids to `VsMenus`.

The shared `ProjectBase` base classes are intentionally left untouched — the overrides
run before them, so legacy (non-SDK) projects are unaffected.

### Notes for reviewers
- Menu ids and command placements were verified against the VS2022 SDK's
  `SharedCmdDef.vsct` / `SharedCmdPlace.vsct` and `vsshlids.h`.
- The `IDM_VS_CTXT_DEPENDENCYTARGET` constant is added for completeness but not yet
  used; the "Frameworks" and target-framework nodes keep `IDM_VS_CTXT_NOCOMMANDS`.
- "Projects" / "Assemblies" are created lazily, so on a project without references only
  the "Dependencies" node exists — which is why it answers all five commands.
- `VsIntegration2022.sln` builds clean (0 errors) with VS2022; verified via
  `msbuild VsIntegration2022.sln /p:Configuration=Debug`.