### PR TITLE
[Vsintegration] Show project references of SDK style projects in the Dependencies node

### DIFF
--- a/src/VisualStudio/ProjectBase/ProjectNode.cs
+++ b/src/VisualStudio/ProjectBase/ProjectNode.cs
@@ -6701,6 +6701,14 @@ namespace Microsoft.VisualStudio.Project
                     var projectInfo = ProjectInfo.GetProjectInfo(url);
                     if (projectInfo == null)
                     {
+                        if (node.ReferencedProjectGuid == Guid.Empty)
+                        {
+                            // The referenced project has not been loaded, so we do not know its guid yet.
+                            // Do not register a ProjectInfo with an empty guid: that would be cached by url
+                            // and would prevent the guid from being resolved later on.
+                            Logger.Information($"No BuildDependency for project {this.Caption} on {url}: the guid of the referenced project is unknown");
+                            continue;
+                        }
                         projectInfo = new ProjectInfo(node.ReferencedProjectGuid, url);
                     }
                     var dependency = new BuildDependency(this, projectInfo.Id);

--- a/src/VisualStudio/ProjectBase/ProjectReferenceNode.cs
+++ b/src/VisualStudio/ProjectBase/ProjectReferenceNode.cs
@@ -252,6 +252,36 @@ namespace Microsoft.VisualStudio.Project
             referencedProjectIsCached = false;
         }
 
+        /// <summary>
+        /// Assign the guid of the referenced project.
+        /// </summary>
+        /// <remarks>
+        /// SDK style project files do not store the guid of the referenced project, so it can only be
+        /// resolved when the referenced project has been loaded. This also updates the build dependency,
+        /// which could not be created when the node was constructed without a guid.
+        /// </remarks>
+        public void UpdateReferencedProjectGuid(Guid guid)
+        {
+            if (guid == this.referencedProjectGuid)
+            {
+                return;
+            }
+            ThreadHelper.ThrowIfNotOnUIThread();
+            if (this.buildDependency != null)
+            {
+                this.ProjectMgr.RemoveBuildDependency(this.buildDependency);
+                this.buildDependency = null;
+            }
+            this.referencedProjectGuid = guid;
+            if (guid != Guid.Empty)
+            {
+                this.buildDependency = new BuildDependency(this.ProjectMgr, guid);
+                this.ProjectMgr.AddBuildDependency(this.buildDependency);
+            }
+            this.DropReferencedProjectCache();
+            this.ReDraw(UIHierarchyElement.Icon);
+        }
+
 
         EnvDTE.Property GetPropertySave(string name, bool onConfig)
         {
@@ -399,21 +429,26 @@ namespace Microsoft.VisualStudio.Project
                 ReferencedProjectName = Path.GetFileNameWithoutExtension(referencedProjectRelativePath);
             }
 
-            // Continue even if project settings cannot be read.
-            try
+            // An SDK style project file does not store the guid of the referenced project, so we may
+            // not have one here, for example when the referenced project has not been loaded yet.
+            // Do not throw in that case: the node must appear in the hierarchy anyway. The guid is
+            // filled in later, see XSharpProjectNode.FixReferences() and UpdateReferencedProjectGuid().
+            if (!Guid.TryParse(guidString, out var guid))
             {
-                this.referencedProjectGuid = new Guid(guidString);
-
+                guid = Guid.Empty;
+            }
+            this.referencedProjectGuid = guid;
+            if (guid != Guid.Empty)
+            {
                 this.buildDependency = new BuildDependency(this.ProjectMgr, this.referencedProjectGuid);
                 this.ProjectMgr.AddBuildDependency(this.buildDependency);
             }
-            finally
+            var name = this.ItemNode.GetMetadata(ProjectFileConstants.Name);
+            if (!string.IsNullOrEmpty(name))
             {
-                //Debug.Assert(this.referencedProjectGuid != Guid.Empty, "Could not retrieve referenced project guidproject file");
-
-                this.ReferencedProjectName = this.ItemNode.GetMetadata(ProjectFileConstants.Name);
-
-                //Debug.Assert(!String.IsNullOrEmpty(this.referencedProjectName), "Could not retrieve referenced project name form project file");
+                // Do not clear the name that was determined above when the metadata could not be written,
+                // which happens for imported items.
+                this.ReferencedProjectName = name;
             }
 
             Uri uri = new Uri(this.ProjectMgr.BaseURI.Uri, this.referencedProjectRelativePath);

--- a/src/VisualStudio/ProjectPackage/Nodes/XSharpProjectNode.cs
+++ b/src/VisualStudio/ProjectPackage/Nodes/XSharpProjectNode.cs
@@ -1490,16 +1490,19 @@ namespace XSharp.Project
                     var refnode = FindProject(completePath);
                     Guid refnodeGuid = Guid.Empty;
                     string refnodeName = child.Caption;
-                    if (refnode == null)
+                    if (refnode != null)
+                    {
+                        refnodeGuid = refnode.ProjectIDGuid;
+                    }
+                    else
                     {
                         // this must be a foreign project reference
                         var projectInfo = ProjectInfo.GetProjectInfo(completePath);
                         if (projectInfo == null)
                         {
-                            if (this.GetProjectGuid(completePath, out refnodeGuid))
+                            if (this.GetProjectGuid(completePath, out refnodeGuid) && refnodeGuid != Guid.Empty)
                             {
                                 projectInfo = new ProjectInfo(refnodeGuid, completePath);
-                                element.SetMetadata(ProjectFileConstants.Project, refnodeGuid.ToString("B").ToUpperInvariant());
                             }
                         }
                         else
@@ -1511,19 +1514,19 @@ namespace XSharp.Project
                     {
                         element.SetMetadata(ProjectFileConstants.Project, refnodeGuid.ToString("B").ToUpperInvariant());
                         element.SetMetadata(ProjectFileConstants.Name, refnodeName);
+                        sdkref.SaveProperties();
+                        // The node was created before the referenced project was available, so it has no
+                        // guid and no build dependency yet.
+                        sdkref.UpdateReferencedProjectGuid(refnodeGuid);
                     }
                     else
                     {
+                        Logger.Information($"Could not determine the guid of project {completePath}, referenced by {this.Caption}");
                         found = false;
                     }
-                    if (found)
-                    {
-                        sdkref.SaveProperties();
-                    }
                 }
-
-                HasIncompleteReferences = !found;
             }
+            HasIncompleteReferences = !found;
             this.SetProjectFileDirty(false);
             return found;
         }

--- a/src/VisualStudio/ProjectPackage/Nodes/XSharpReferenceContainerNode.cs
+++ b/src/VisualStudio/ProjectPackage/Nodes/XSharpReferenceContainerNode.cs
@@ -39,16 +39,39 @@ namespace XSharp.Project
             bool changed = false;
             if (parent.IsSdkProject)
             {
-                // already handled in the DependenciesContainer
+                // An SDK style project file does not store the guid and the name of the referenced project,
+                // so we resolve them here and store them in the (in memory) project element. The base
+                // ProjectReferenceNode reads them from there. BeforeSave() removes them again, so they are
+                // not written to the project file, see XSharpSdkProjectNode.Clean().
                 name = System.IO.Path.GetFileNameWithoutExtension(path);
+                guid = null;
                 if (refnode != null)
                 {
                     guid = refnode.ProjectIDGuid.ToString("B");
                 }
                 else
                 {
-                    guid = null;
+                    // Not one of our projects, or a project that has not been loaded yet
+                    var projectInfo = ProjectInfo.GetProjectInfo(path);
+                    if (projectInfo == null && parent.GetProjectGuid(path, out var foreignGuid) && foreignGuid != Guid.Empty)
+                    {
+                        projectInfo = new ProjectInfo(foreignGuid, path);
+                    }
+                    if (projectInfo != null && projectInfo.Id != Guid.Empty)
+                    {
+                        guid = projectInfo.Id.ToString("B");
+                    }
+                }
+                element.SetMetadata(ProjectFileConstants.Name, name);
+                if (string.IsNullOrEmpty(guid))
+                {
+                    // The referenced project is not available yet. The node is created without a guid and
+                    // FixReferences() completes it when the solution has finished loading.
                     parent.HasIncompleteReferences = true;
+                }
+                else
+                {
+                    element.SetMetadata(ProjectFileConstants.Project, guid);
                 }
             }
             else if (string.IsNullOrEmpty(guid) || string.IsNullOrEmpty(name))
@@ -84,7 +107,17 @@ namespace XSharp.Project
                 parent.BuildProject.Save();
             }
 
-            var node = (XSharpProjectReferenceNode) Activator.CreateInstance(ProjectReferenceType,this.ProjectMgr, element);
+            XSharpProjectReferenceNode node = null;
+            try
+            {
+                node = (XSharpProjectReferenceNode)Activator.CreateInstance(ProjectReferenceType, this.ProjectMgr, element);
+            }
+            catch (Exception e)
+            {
+                // Do not let this bubble up: ReferenceContainerNode.CreateReferenceNode() swallows the
+                // exception without logging it and the reference would disappear from the hierarchy.
+                Logger.Exception(e, "CreateProjectReferenceNode");
+            }
             ReferenceNode existing = null;
             if (isDuplicateNode(node, ref existing))
             {

--- a/src/VisualStudio/ProjectPackage/XSharpShellEvents.cs
+++ b/src/VisualStudio/ProjectPackage/XSharpShellEvents.cs
@@ -86,17 +86,23 @@ namespace XSharp.Project
 #if DEV17
         private void SolutionEvents_OnAfterOpenSolution(Solution solution)
         {
+            FixIncompleteReferences();
+        }
 
+        /// <summary>
+        /// Complete the project references of SDK style projects that could not be resolved while the
+        /// project was loading, because the referenced project was not loaded yet.
+        /// </summary>
+        private void FixIncompleteReferences()
+        {
             foreach (var project in XSharpProjectNode.AllProjects)
             {
                 if (project.HasIncompleteReferences)
                 {
-
                     project.FixReferences();
                 }
             }
-
-    }
+        }
 #endif
         private void SolutionEvents_OnBeforeCloseSolution()
         {
@@ -129,6 +135,11 @@ namespace XSharp.Project
         private void SolutionEvents_OnAfterBackgroundSolutionLoadComplete()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
+#if DEV17
+            // Projects may have been loaded after OnAfterOpenSolution, so check again now that all
+            // projects of the solution are available.
+            FixIncompleteReferences();
+#endif
             RestoreDesignerWindows();
             RestoreStartupProject();
         }


### PR DESCRIPTION
The **Projects** node under **Dependencies** stayed empty when a solution with SDK style X# projects was opened. It only showed up after adding a project reference through the dialog, and was gone again after the next reload.

## Root cause

No `ProjectReferenceNode` was created at all:

1. `XSharpSdkProjectNode.Clean()` strips the `Project` (guid) and `Name` metadata from every `ProjectReference` item before saving, so a saved `.xsproj` correctly only contains `<ProjectReference Include="..\Foo\Foo.xsproj" />`.
2. `XSharpReferenceContainerNode.CreateProjectReferenceNode()` resolved `guid` and `name` for the SDK case — and then dropped both on the floor. Nothing was written to the project element.
3. The `ProjectReferenceNode(ProjectNode, ProjectElement)` constructor deliberately skips the "invent a random guid" fallback for SDK projects, and then called `new Guid(guidString)` on an empty string inside a `try`/**`finally`** with no `catch` → `FormatException`.
4. `ReferenceContainerNode.CreateReferenceNode()` swallows that exception (a `Debug.WriteLine` only when a debugger is attached) and returns `null`.
5. The `Projects` folder is created lazily, on the first `XSharpProjectReferenceNode` that is added — so the whole folder was missing, not just the reference.

Adding a reference interactively goes through the other constructor, which parses the guid out of the `bstrProjRef` string, which is why that path worked.

`FixReferences()`, the mechanism meant to complete these references once the solution has finished loading, had nothing left to iterate over. It was broken on its own as well: when the referenced project *was* found (`refnode != null`) it never assigned `refnodeGuid`, so it always reported failure.

## Changes

- **`XSharpReferenceContainerNode`** — the SDK branch now stores the resolved guid and name on the in-memory project element, and resolves foreign / not-yet-loaded projects via `ProjectInfo` / `GetProjectGuid`, the same way `FixReferences()` does. `Clean()` still keeps them out of the saved project file. Node creation is wrapped in `try`/`catch` + `Logger.Exception`, consistent with the sibling `Create*Node` methods, so a failure can never silently drop a reference again.
- **`ProjectReferenceNode`** — tolerate a missing or malformed guid: the node is created with `Guid.Empty` and without a build dependency instead of throwing, so it always appears in the hierarchy. Added `UpdateReferencedProjectGuid()` to attach the guid and the build dependency later and redraw the icon.
- **`XSharpProjectNode.FixReferences()`** — use `refnode.ProjectIDGuid` when the referenced project is one of ours; resolve per node instead of skipping the remaining nodes after the first failure; push the resolved guid into the node; log what stayed unresolved.
- **`ProjectNode.BuildDependencies`** — do not register a `ProjectInfo` with an empty guid. It is cached by url and would block the later resolution of the real guid.
- **`XSharpShellEvents`** — also complete incomplete references on `OnAfterBackgroundSolutionLoadComplete`. With deferred solution load not all projects exist yet when `OnAfterOpenSolution` fires.

## Notes for reviewers

- Behaviour for legacy (non-SDK) projects is unchanged: an empty guid still gets the random-guid fallback. The only difference there is that a *malformed* guid no longer throws away the node.
- The in-memory `Project`/`Name` metadata does not reach the project file: `ProjectNode.Save()` calls `BeforeSave()` → `XSharpSdkProjectNode.Clean()`, which removes it, and `Save()` restores it afterwards via `RestoreProperties()`. `Reload()` clears the dirty flag in its `finally`, so writing the metadata during `ProcessReferences()` does not leave the project dirty.
- `ProjectPackage2022` builds clean. The VS2019 variant (`ProjectPackage.csproj`) does not build in my working tree, but that is pre-existing and unrelated — NuGet restore for `net472` plus missing `Community.VisualStudio.Toolkit` types in `Support.csproj`/`Logger.cs`, files this PR does not touch.
- Not verified in the running IDE yet: worth a check that **Dependencies → Projects** is populated on load and that project build order is still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
