### PR TITLE
Fix: set date returns country

### DIFF
--- a/src/Common/set.xh
+++ b/src/Common/set.xh
@@ -47,6 +47,7 @@
 #command  SET DATE [TO] <x:AMERICAN,MDY>        =>  SetDateCountry(DateCountry.American)
 #command  SET DATE [TO] ANSI                    =>  SetDateCountry(DateCountry.Ansi)
 #command  SET DATE [TO] <x:BRITISH,FRENCH,DMY>  =>  SetDateCountry(DateCountry.British)
+#command  SET DATE [TO] FRENCH                  =>  SetDateCountry(DateCountry.French)
 #command  SET DATE [TO] GERMAN                  =>  SetDateCountry(DateCountry.German)
 #command  SET DATE [TO] <x:ITALIAN,DUTCH>       =>  SetDateCountry(DateCountry.Italian)
 #command  SET DATE [TO] <x:JAPANESE,TAIWAN,YMD> =>  SetDateCountry(DateCountry.Japanese)

--- a/src/Runtime/XSharp.RT/Functions/Set.prg
+++ b/src/Runtime/XSharp.RT/Functions/Set.prg
@@ -214,6 +214,23 @@ FUNCTION Set(nDefine, newValue) AS USUAL CLIPPER
                 END TRY
             ENDIF
         ENDIF
+
+        // FoxPro returns the country keyword ?SET("DATE")
+        IF cOriginalDefine == "DATE"
+            VAR eCountry := (XSharp.DateCountry) RuntimeState.DateCountry
+            SWITCH eCountry
+            CASE XSharp.DateCountry.Japanese
+                // VFP returns JAPAN
+                oOld := "JAPAN"
+            CASE XSharp.DateCountry.System
+                oOld := "SHORT"
+            CASE XSharp.DateCountry.Italian
+                oOld := "ITALIAN"
+            OTHERWISE
+                oOld := Enum.GetName(typeof(XSharp.DateCountry), eCountry):ToUpperInvariant()
+            END SWITCH
+        ENDIF
+
     ENDIF
 
     RETURN oOld

--- a/src/Runtime/XSharp.VFP.Tests/SetDateCommandTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/SetDateCommandTests.prg
@@ -187,6 +187,89 @@ BEGIN NAMESPACE XSharp.VFP.Tests
             END TRY
         END METHOD
 
+        [Fact, Trait("Category", "SetDate")];
+        METHOD SetDateQueryReturnsTheCountryKeywordNotThePicture AS VOID
+            VAR cOld := GetDateFormat()
+            TRY
+                SET CENTURY ON
+                SET DATE TO GERMAN
+                Assert.Equal("GERMAN", (STRING) Set("DATE"))
+                Assert.Equal("DD.MM.YYYY", (STRING) Set("DATEFORMAT"))
+            FINALLY
+                SetDateFormat(cOld)
+            END TRY
+        END METHOD
+
+        [Fact, Trait("Category", "SetDate")];
+        METHOD SetDateQueryReturnsEveryKeyword AS VOID
+            LOCAL cKw AS STRING
+            VAR cOld := GetDateFormat()
+            TRY
+                SET CENTURY ON
+                FOREACH oPair AS STRING[] IN <STRING[]>{ ;
+                        <STRING>{"AMERICAN", "AMERICAN"}, ;
+                        <STRING>{"ANSI"    , "ANSI"    }, ;
+                        <STRING>{"BRITISH" , "BRITISH" }, ;
+                        <STRING>{"FRENCH"  , "FRENCH"  }, ;
+                        <STRING>{"GERMAN"  , "GERMAN"  }, ;
+                        <STRING>{"ITALIAN" , "ITALIAN" }, ;
+                        <STRING>{"DUTCH"   , "ITALIAN" }, ;
+                        <STRING>{"JAPAN"   , "JAPAN"   }, ;
+                        <STRING>{"JAPANESE", "JAPAN"   }, ;
+                        <STRING>{"USA"     , "USA"     }, ;
+                        <STRING>{"SHORT"   , "SHORT"   }  ;
+                    }
+                    cKw := oPair[1]
+                    SET DATE TO (cKw)
+                    Assert.Equal(oPair[2], (STRING) Set("DATE"))
+                NEXT
+            FINALLY
+                SetDateFormat(cOld)
+            END TRY
+        END METHOD
+
+        [Fact, Trait("Category", "SetDate")];
+        METHOD SetDateQueryCollapsesAliasKeywords_KnownLimitation AS VOID
+            LOCAL cKw AS STRING
+            VAR cOld := GetDateFormat()
+            TRY
+                SET CENTURY ON
+                FOREACH oPair AS STRING[] IN <STRING[]>{ ;
+                        <STRING>{"TAIWAN", "JAPAN"   }, ;
+                        <STRING>{"MDY"   , "AMERICAN"}, ;
+                        <STRING>{"DMY"   , "BRITISH" }, ;
+                        <STRING>{"YMD"   , "JAPAN"   }  ;
+                    }
+                    cKw := oPair[1]
+                    SET DATE TO (cKw)
+                    Assert.Equal(oPair[2], (STRING) Set("DATE"))
+                NEXT
+            FINALLY
+                SetDateFormat(cOld)
+            END TRY
+        END METHOD
+
+        [Fact, Trait("Category", "SetDate")];
+        METHOD SetDateQueryWorksForLiteralKeywordsToo AS VOID
+            VAR cOld := GetDateFormat()
+            TRY
+                SET CENTURY ON
+                SET DATE TO AMERICAN
+                Assert.Equal("AMERICAN", (STRING) Set("DATE"))
+                SET DATE TO ANSI
+                Assert.Equal("ANSI", (STRING) Set("DATE"))
+                SET DATE TO FRENCH
+                Assert.Equal("FRENCH", (STRING) Set("DATE"))
+                SET DATE TO ITALIAN
+                Assert.Equal("ITALIAN", (STRING) Set("DATE"))
+                SET DATE TO JAPANESE
+                Assert.Equal("JAPAN", (STRING) Set("DATE"))
+                SET DATE TO USA
+                Assert.Equal("USA", (STRING) Set("DATE"))
+            FINALLY
+                SetDateFormat(cOld)
+            END TRY
+        END METHOD
     END CLASS
 
 END NAMESPACE


### PR DESCRIPTION
`SET("DATE")` returned the date picture (`DD.MM.YYYY`) instead of the country keyword eg: (`GERMAN`).