### PR TITLE
Fix WAIT WINDOW when the message follows WINDOW

### DIFF
--- a/src/Common/FoxProCmd.xh
+++ b/src/Common/FoxProCmd.xh
@@ -169,6 +169,18 @@
 #xcommand WAIT <msg> TO <v> [<win:WINDOW> [AT <nRow>, <nCol>]] [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
     => <v> := __VfpWait(<msg>, <.win.>, <!nRow!>, <!nCol!>, <.now.>, <.nclr.>, <!secs!>)
 
+#xcommand WAIT WINDOW <msg> [AT <nRow>, <nCol>] [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
+    => __VfpWait(<msg>, TRUE, <!nRow!>, <!nCol!>, <.now.>, <.nclr.>, <!secs!>)
+
+#xcommand WAIT WINDOW <msg> TO <v> [AT <nRow>, <nCol>] [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
+    => <v> := __VfpWait(<msg>, TRUE, <!nRow!>, <!nCol!>, <.now.>, <.nclr.>, <!secs!>)
+
+#xcommand WAIT WINDOW <msg> AT <nRow>, <nCol> TO <v> [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
+    => <v> := __VfpWait(<msg>, TRUE, <nRow>, <nCol>, <.now.>, <.nclr.>, <!secs!>)
+
+#xcommand WAIT WINDOW TO <v> [AT <nRow>, <nCol>] [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
+    => <v> := __VfpWait(NIL, TRUE, <!nRow!>, <!nCol!>, <.now.>, <.nclr.>, <!secs!>)
+
 #xcommand WAIT [<win:WINDOW> [AT <nRow>, <nCol>]] [<now:NOWAIT>] [<nclr:NOCLEAR>] [TIMEOUT <secs>] ;
     => __VfpWait(NIL, <.win.>, <!nRow!>, <!nCol!>, <.now.>, <.nclr.>, <!secs!>)
 

--- a/src/Runtime/XSharp.VFP.Tests/WaitCommandTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/WaitCommandTests.prg
@@ -1,0 +1,73 @@
+﻿//
+// Copyright (c) XSharp B.V.  All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+// See License.txt in the project root for license information.
+//
+
+USING System
+USING XUnit
+
+BEGIN NAMESPACE XSharp.VFP.Tests
+    CLASS WaitCommandTests
+
+        STATIC CONSTRUCTOR
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+        END CONSTRUCTOR
+
+        [Fact, Trait("Category", "Wait")];
+        METHOD WaitWindowAcceptsTheMessageAfterTheWindowKeyword AS VOID
+            WAIT WINDOW "x" NOWAIT
+            WAIT WINDOW "x" AT 10, 20 NOWAIT
+            WAIT WINDOW "x" NOWAIT NOCLEAR
+        END METHOD
+
+        [Fact, Trait("Category", "Wait")];
+        METHOD WaitWindowWithMessageStoresTheResult AS VOID
+            LOCAL cKey AS STRING
+            cKey := "unset"
+            WAIT WINDOW "x" TO cKey NOWAIT
+            Assert.Equal("", cKey)
+        END METHOD
+
+        [Fact, Trait("Category", "Wait")];
+        METHOD WaitWindowAcceptsAtBeforeTo AS VOID
+            LOCAL cKey AS STRING
+            cKey := "unset"
+            WAIT WINDOW "x" AT 10, 20 TO cKey NOWAIT
+            Assert.Equal("", cKey)
+        END METHOD
+
+        [Fact, Trait("Category", "Wait")];
+        METHOD WaitWindowAcceptsToBeforeAt AS VOID
+            LOCAL cKey AS STRING
+            cKey := "unset"
+            WAIT WINDOW "x" TO cKey AT 10, 20 NOWAIT
+            Assert.Equal("", cKey)
+        END METHOD
+
+        [Fact, Trait("Category", "Wait")];
+        METHOD WaitWindowWithoutMessageStoresTheResult AS VOID
+            LOCAL cKey AS STRING
+            cKey := "unset"
+            WAIT WINDOW TO cKey NOWAIT
+            Assert.Equal("", cKey)
+        END METHOD
+
+        [Fact, Trait("Category", "Wait")];
+        METHOD WaitStillAcceptsTheMessageBeforeTheWindowKeyword AS VOID
+            LOCAL cKey AS STRING
+            cKey := "unset"
+            WAIT "x" WINDOW NOWAIT
+            WAIT "x" TO cKey WINDOW AT 3, 3 NOWAIT
+            Assert.Equal("", cKey)
+        END METHOD
+
+        [Fact, Trait("Category", "Wait")];
+        METHOD WaitWithoutMessageStillWorks AS VOID
+            WAIT WINDOW NOWAIT
+            WAIT WINDOW AT 5, 5 NOWAIT
+            WAIT CLEAR
+        END METHOD
+
+    END CLASS
+END NAMESPACE

--- a/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
+++ b/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
@@ -119,6 +119,7 @@
     <Compile Include="StringTests.prg" />
     <Compile Include="UdcCommandFixTests.prg" />
     <Compile Include="VfpStringFunctionsTests.prg" />
+    <Compile Include="WaitCommandTests.prg" />
     <Compile Include="WrappedStubsTests.prg" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #1992 

I hope this is the last PR I do on the WAIT WINDOW rule ;-). Every time I patch one, another crack show up somethere else, that's driving me crazy.

I checked every combination against a real VFP 9 and all of these are valid there:

```
WAIT WINDOW <msg> [AT r,c] [NOWAIT] [NOCLEAR] [TIMEOUT n]
WAIT WINDOW <msg> TO <v>
WAIT WINDOW <msg> AT r,c TO <v>
WAIT WINDOW TO <v>
```

Fingers crossed.
