### PR TITLE
[VsIntegration] Fix reference resolution: marshal AddPendingReference…

### DIFF
--- a/src/VisualStudio/ProjectPackage/NodesSDK/SdkProjectNode.cs
+++ b/src/VisualStudio/ProjectPackage/NodesSDK/SdkProjectNode.cs
@@ -744,6 +744,19 @@ namespace XSharp.Project
 
         private void AddPendingReferences(List<string> newReferences, SdkSubProjectInfo active)
         {
+            // Callers include XSharpIDEBuildLogger.ProjectFinishedHandler, which runs on
+            // an MSBuild logger (background) thread, but this method disposes
+            // XSharpDependencyNode (an AssemblyReferenceNode), whose Dispose() requires
+            // the UI thread. Marshal onto the UI thread before touching any hierarchy node.
+            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                AddPendingReferencesOnUIThread(newReferences, active);
+            });
+        }
+
+        private void AddPendingReferencesOnUIThread(List<string> newReferences, SdkSubProjectInfo active)
+        {
             HierarchyNode frameworkNode = null;
             if (SubProjects.Count > 1)
                 frameworkNode = active.TargetFrameworkReferenceNode;


### PR DESCRIPTION
XSharpSdkProjectNode.AddPendingReferences disposes an AssemblyReferenceNode, which requires the UI thread, but is called from ProjectFinishedHandler (an MSBuild logger callback that runs on a background thread). 
This threw a COMException that was silently swallowed by the caller's own try/catch, so RefreshReferencesFromResponseFile() never ran and NuGet-sourced 3rd-party references never got picked up after a build.