### PR TITLE
Add tests for numeric properties in DEFINE CLASS

### DIFF
--- a/src/Runtime/XSharp.VFP.Tests/OOPTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/OOPTests.prg
@@ -16,14 +16,14 @@ begin namespace XSharp.VFP.Tests
 
         [Fact, Trait("Category", "OOP")];
         method NumericPropertyIsUsableInArithmetic as void
-            var oCircle := Circle{}
+            local oCircle := Circle{} as Circle
             oCircle:Ratio := 5
             Assert.Equal(31.4, (real8)oCircle:Perimeter(), 2)
         end method
 
         [Fact, Trait("Category", "OOP")];
         method NumericPropertyRoundTripsThroughLateBoundAccess as void
-            var oCircle := Circle{}
+            local oCircle := Circle{} as Usual
             oCircle:Ratio := 5
             Assert.Equal(10, (int)(oCircle:Ratio * 2))
         end method

--- a/src/Runtime/XSharp.VFP.Tests/OOPTests.prg
+++ b/src/Runtime/XSharp.VFP.Tests/OOPTests.prg
@@ -1,0 +1,39 @@
+﻿//
+// Copyright (c) XSharp B.V.  All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+// See License.txt in the project root for license information.
+//
+
+
+using System
+using XUnit
+
+begin namespace XSharp.VFP.Tests
+    class OOPTests
+        static constructor
+            XSharp.RuntimeState.Dialect := XSharpDialect.FoxPro
+        end constructor
+
+        [Fact, Trait("Category", "OOP")];
+        method NumericPropertyIsUsableInArithmetic as void
+            var oCircle := Circle{}
+            oCircle:Ratio := 5
+            Assert.Equal(31.4, (real8)oCircle:Perimeter(), 2)
+        end method
+
+        [Fact, Trait("Category", "OOP")];
+        method NumericPropertyRoundTripsThroughLateBoundAccess as void
+            var oCircle := Circle{}
+            oCircle:Ratio := 5
+            Assert.Equal(10, (int)(oCircle:Ratio * 2))
+        end method
+    end class
+
+    define class Circle as Custom
+        ratio = 0
+
+        procedure Perimeter()
+            return 2 * 3.14 * this.ratio
+        endproc
+    enddefine
+end namespace

--- a/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
+++ b/src/Runtime/XSharp.VFP.Tests/XSharp.VFP.Tests.xsproj
@@ -104,6 +104,7 @@
     <Compile Include="IndexOnTrimTests.prg" />
     <Compile Include="IntrospectionTests.prg" />
     <Compile Include="KeyMatchLookupTests.prg" />
+    <Compile Include="OOPTests.prg" />
     <Compile Include="ReplaceScopeTests.prg" />
     <Compile Include="SetDateCommandTests.prg" />
     <Compile Include="SQLStatementTests.prg" />


### PR DESCRIPTION
I noticed there is no test anywhere that uses DEFINE CLASS, so I added a small one. This is not a fix but a guard on two facts: one reads the property through the typed object, the other through a USUAL so the access goes late bound.