### PR TITLE
Logging Exception with stacktrace and as arror

### DIFF
--- a/src/VisualStudio/Support/Logger.cs
+++ b/src/VisualStudio/Support/Logger.cs
@@ -402,7 +402,7 @@ namespace XSharp.Support
 
         public void Exception(Exception e, string sMsg)
         {
-            Logger.Debug(sMsg);
+            Logger.Exception(e, sMsg);
         }
 
         public void Information(string sMsg)


### PR DESCRIPTION
At the moment exceptions are logged only as debug and without stacktrace