### PR TITLE
GetCacheClassesOurAssemblies added to get all already cached types

### DIFF
--- a/src/Runtime/XSharp.RT/Functions/OOP.prg
+++ b/src/Runtime/XSharp.RT/Functions/OOP.prg
@@ -2373,3 +2373,5 @@ function EnableLBOptimizations(lSet as logic) as logic
     OOPHelpers.EnableOptimizations := lSet
     return lOld
 
+public function GetCacheClassesOurAssemblies() as ConcurrentDictionary<string, Type>
+    return OOPHelpers.cacheClassesOurAssemblies


### PR DESCRIPTION
To load assemblies that are unknown to the program, we need to know which types are currently known.