### PR TITLE
Fix DefaultItemExcludes handling in XSharp.SDK.Props

### DIFF
--- a/src/Compiler/src/Compiler/XSharpBuildTask/XSharp.SDK.Props
+++ b/src/Compiler/src/Compiler/XSharpBuildTask/XSharp.SDK.Props
@@ -17,7 +17,10 @@ Copyright (C) XSharp BV. All rights reserved.
     <AppXamlFiles>**\App.xaml</AppXamlFiles>
     <HeaderFiles>**\*.vh;**\*.xh</HeaderFiles>
     <!-- App.xaml files need special item type ApplicationDefinition, so exclude these as well -->
-    <DefaultItemExcludes>$(VOBinaryFiles);$(AppXamlFiles);$(HeaderFiles);**/*.rc;**/*.resx;**/*.designer.prg;**/*.xaml.prg</DefaultItemExcludes>
+    <!-- $(DefaultItemExcludes) must be preserved: the value set by the user in Directory.Build.props
+         is evaluated before this file. Assigning without it silently discards their setting, unlike
+         Microsoft.NET.Sdk.DefaultItems.props, which always appends. -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(VOBinaryFiles);$(AppXamlFiles);$(HeaderFiles);**/*.rc;**/*.resx;**/*.designer.prg;**/*.xaml.prg</DefaultItemExcludes>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Compiler/src/Compiler/XSharpBuildTask/XSharp.SDK.Props
+++ b/src/Compiler/src/Compiler/XSharpBuildTask/XSharp.SDK.Props
@@ -16,6 +16,19 @@ Copyright (C) XSharp BV. All rights reserved.
     <VOBinaryFiles>**\*.xsfs;**\*.xsdbs;**\*.xsmnu;**\*.xsfrm;**\*.xsrep;**\*.xssql;**/*.vnfs;**/*.vndbs;**/*.vnmnu;**/*.vnfrm</VOBinaryFiles>
     <AppXamlFiles>**\App.xaml</AppXamlFiles>
     <HeaderFiles>**\*.vh;**\*.xh</HeaderFiles>
+    <!-- Exclusions for the globs below. This must be captured BEFORE the item types owned by
+         X# are appended to DefaultItemExcludes: using the appended value would exclude exactly
+         the files these globs are meant to collect.
+         $(DefaultExcludesInProjectFolder) is still empty here (Microsoft.NET.Sdk.DefaultItems.props
+         is imported after this file) and is listed so the value is picked up should that order
+         ever change. The output directories are added explicitly for the same reason - they are
+         only appended to DefaultItemExcludes later, which is too late for the globs below. -->
+    <XSharpDefaultItemExcludes>$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)</XSharpDefaultItemExcludes>
+    <XSharpDefaultItemExcludes Condition="'$(BaseOutputPath)' != ''">$(XSharpDefaultItemExcludes);$(BaseOutputPath)/**</XSharpDefaultItemExcludes>
+    <XSharpDefaultItemExcludes Condition="'$(BaseIntermediateOutputPath)' != ''">$(XSharpDefaultItemExcludes);$(BaseIntermediateOutputPath)/**</XSharpDefaultItemExcludes>
+    <XSharpDefaultItemExcludes Condition="'$(OutputPath)' != ''">$(XSharpDefaultItemExcludes);$(OutputPath)/**</XSharpDefaultItemExcludes>
+    <XSharpDefaultItemExcludes Condition="'$(IntermediateOutputPath)' != ''">$(XSharpDefaultItemExcludes);$(IntermediateOutputPath)/**</XSharpDefaultItemExcludes>
+
     <!-- App.xaml files need special item type ApplicationDefinition, so exclude these as well -->
     <!-- $(DefaultItemExcludes) must be preserved: the value set by the user in Directory.Build.props
          is evaluated before this file. Assigning without it silently discards their setting, unlike
@@ -25,24 +38,24 @@ Copyright (C) XSharp BV. All rights reserved.
   
   <ItemGroup>
     <!-- App.xaml files need special item type ApplicationDefinition -->
-    <ApplicationDefinition Include="$(AppXamlFiles)">
+    <ApplicationDefinition Include="$(AppXamlFiles)" Exclude="$(XSharpDefaultItemExcludes)">
       <Generator>MSBuild:Compile</Generator>
     </ApplicationDefinition>
     <!-- Add our own definitions for the VOBinary items with calculated dependentupon properti -->
-    <VOBinary Include="$(VOBinaryFiles)"  KeepDuplicates="false">
+    <VOBinary Include="$(VOBinaryFiles)" Exclude="$(XSharpDefaultItemExcludes)" KeepDuplicates="false">
       <ParentName>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)%(Extension)', '\.[^.]+\%(Extension)$', '.prg'))</ParentName>
       <DependentUpon Condition="Exists('%(ParentName)')">%(ParentName)</DependentUpon>
     </VOBinary>
-    <NativeResource Include="**/*.rc" >
+    <NativeResource Include="**/*.rc" Exclude="$(XSharpDefaultItemExcludes)" >
       <ParentName>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)%(Extension)', '\.[^.]+\%(Extension)$', '.prg'))</ParentName>
       <DependentUpon Condition="Exists('%(ParentName)')">%(ParentName)</DependentUpon>
     </NativeResource >
-	<Compile Include="**/*.xaml.prg"  KeepDuplicates="false" >
+	<Compile Include="**/*.xaml.prg" Exclude="$(XSharpDefaultItemExcludes)" KeepDuplicates="false" >
 	   <!-- .xaml.prg can depend on xaml -->
       <ParentXamlName>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)%(Extension)', '.xaml.prg$', '.xaml', System.Text.RegularExpressions.RegexOptions.IgnoreCase))</ParentXamlName>
       <DependentUpon Condition="Exists('%(ParentXamlName)')">%(ParentXamlName)</DependentUpon>
 	</Compile>
-    <Compile Include="**/*.designer.prg"  KeepDuplicates="false" >
+    <Compile Include="**/*.designer.prg" Exclude="$(XSharpDefaultItemExcludes)" KeepDuplicates="false" >
       <!-- Designer.prg can depend on prg, resx or settings -->
       <ParentPrgName>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)%(Extension)', '.designer.prg$', '.prg', System.Text.RegularExpressions.RegexOptions.IgnoreCase))</ParentPrgName>
       <ParentResxName>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)%(Extension)', '.designer.prg$', '.resx', System.Text.RegularExpressions.RegexOptions.IgnoreCase))</ParentResxName>
@@ -51,12 +64,12 @@ Copyright (C) XSharp BV. All rights reserved.
       <DependentUpon Condition="Exists('%(ParentResxName)')">%(ParentResxName)</DependentUpon>
       <DependentUpon Condition="Exists('%(ParentSettingsName)')">%(ParentSettingsName)</DependentUpon>
     </Compile>
-    <EmbeddedResource Include="**/*.resx"   KeepDuplicates="false">
+    <EmbeddedResource Include="**/*.resx" Exclude="$(XSharpDefaultItemExcludes)" KeepDuplicates="false">
       <!-- This handles .resx that depends on a prg -->
       <ParentName>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)%(Extension)', '%(Extension)$', '.prg'))</ParentName>
       <DependentUpon Condition="Exists('%(ParentName)')">%(ParentName)</DependentUpon>
     </EmbeddedResource>
-    <None Include="$(HeaderFiles)"  KeepDuplicates="false">
+    <None Include="$(HeaderFiles)" Exclude="$(XSharpDefaultItemExcludes)" KeepDuplicates="false">
       <!-- This handles header files that depend on a prg -->
       <ParentName>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)%(Extension)', '%(Extension)$', '.prg'))</ParentName>
       <DependentUpon Condition="Exists('%(ParentName)')">%(ParentName)</DependentUpon>


### PR DESCRIPTION
## Two independent defects in `XSharp.SDK.Props`

Both were found while tracking down sporadic `XS9014` / `XS9019` errors in a solution where a classic and an SDK-style project share one directory. Each commit stands on its own.

### 1. `DefaultItemExcludes` is assigned, not appended

```xml
<DefaultItemExcludes>$(VOBinaryFiles);$(AppXamlFiles);$(HeaderFiles);...</DefaultItemExcludes>
```

`Microsoft.NET.Sdk.DefaultItems.props` always writes `$(DefaultItemExcludes);…`. Here the inherited value is dropped, so anything a user sets in `Directory.Build.props` is silently ignored for `.xsproj` while it works as documented for `.csproj`. That is a surprising difference to debug — nothing fails, the setting just has no effect.

Evaluation order confirms the fix is narrow: with `-v:diag` on a real project, the final value contains the X# list **followed by** `$(BaseOutputPath)/**`, `$(BaseIntermediateOutputPath)/**`, `publish/**`, `**/*.user`. Those come from the .NET SDK, which is imported after this file, so the prefix picks up user values only.

### 2. The X# item globs have no `Exclude`

```xml
<EmbeddedResource Include="**/*.resx" KeepDuplicates="false">
<Compile Include="**/*.designer.prg" KeepDuplicates="false">
<NativeResource Include="**/*.rc">
```

These reach into `obj\` and `bin\`. Any generated file left there from an earlier configuration becomes a project item, which shows up as `XS0579` / `CS0579` *Duplicate attribute*. It is easy to hit whenever `IntermediateOutputPath` changes and the old directory stays on disk.

`Exclude="$(XSharpDefaultItemExcludes)"` is added to all seven globs. Two details worth reviewing:

* The property is computed **before** the item types owned by X# are appended to `DefaultItemExcludes`. Using the appended value would exclude exactly the files these globs are meant to collect.
* The output directories are listed explicitly, because the .NET SDK appends them to `DefaultItemExcludes` only after this file is imported — too late for these globs. `Condition="'$(BaseOutputPath)' != ''"` guards keep a bare `/**` from being formed.

`$(DefaultExcludesInProjectFolder)` is referenced although it is still empty at this point, so the value is picked up should the import order ever change.

## Verification

The file was evaluated standalone against a directory tree with decoys in `obj\Debug\` and `bin\Debug\`:

```
EXCL=[;;bin\/**;obj\/**]
EmbeddedResource=[a.resx]        obj\Debug\stale.resx, bin\Debug\old.resx not collected
Compile=[foo.designer.prg]       obj\Debug\gen.designer.prg not collected
NativeResource=[r.rc]            bin\Debug\old.rc not collected
VOBinary=[x.xsfrm]  None=[a.vh]  ApplicationDefinition=[App.xaml]

-p:DefaultItemExcludes=meins\**  ->  EXCL=[meins\**;;bin\/**;obj\/**]
```

Not verified inside a full SDK build — that needs the file deployed to `C:\Program Files (x86)\XSharp\MSBuild\`. The import-order assumptions above are taken from a `-v:diag` evaluation of a real `.xsproj`.

## Not included

The same `ItemGroup` also ignores `$(EnableDefaultItems)` and the per-type switches (`EnableDefaultCompileItems`, `EnableDefaultEmbeddedResourceItems`, …); the .NET SDK guards every default item group with them. Fixing that *removes* items from projects that set `EnableDefaultItems=false` and rely on the current behaviour, so it is left out here and is worth its own discussion.